### PR TITLE
refactor: add error handling to proposal list

### DIFF
--- a/plugins/crispVoting/pages/proposal-list.tsx
+++ b/plugins/crispVoting/pages/proposal-list.tsx
@@ -50,13 +50,6 @@ export default function Proposals() {
         })
         .catch((err) => {
           console.error("Could not fetch the proposals", err);
-
-          if (!logs || !Array.isArray(logs) || !logs.length) {
-            setProposalIds([]);
-            return;
-          }
-
-          return;
         });
 
       if (!logs || !Array.isArray(logs) || !logs.length) {


### PR DESCRIPTION
Fixes #22 

Error:
```
Cannot read properties of undefined (reading 'map')
```

It's quite hard to replicate, and it has something to do with the `getLogs` method of the `client` object of Viem.