### PR TITLE
fix: address CodeRabbit review on #79

### DIFF
--- a/pages/api/etherscan.ts
+++ b/pages/api/etherscan.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { buildEtherscanUpstreamQuery } from "@/utils/etherscan-query";
 
 /**
  * Server-side Etherscan V2 proxy.
@@ -41,11 +42,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const url = new URL(ETHERSCAN_V2);
-  for (const [key, value] of Object.entries(req.query)) {
-    if (key === "apikey") continue; // never let a caller override the server key
-    url.searchParams.set(key, Array.isArray(value) ? (value[0] ?? "") : String(value ?? ""));
+  for (const [key, value] of buildEtherscanUpstreamQuery(req.query, ETHERSCAN_API_KEY)) {
+    url.searchParams.set(key, value);
   }
-  url.searchParams.set("apikey", ETHERSCAN_API_KEY);
 
   // Bound the upstream call. Without a deadline a stalled Etherscan response holds this function
   // open until the platform's own, much longer, timeout — and enough concurrent stalls exhaust the
@@ -60,13 +59,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
     const body = await upstream.text();
 
+    res.setHeader("Content-Type", "application/json");
+
+    if (!upstream.ok) {
+      // Never cache a failure. The 502 below is OUR translation of an upstream error, and a shared
+      // cache holding it for an hour would keep serving the failure long after Etherscan recovered.
+      res.setHeader("Cache-Control", "no-store");
+      return res.status(502).send(body);
+    }
+
     // ABIs are immutable for a given address; let the CDN absorb repeat lookups.
     res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
-    res.setHeader("Content-Type", "application/json");
-    return res.status(upstream.ok ? 200 : 502).send(body);
+    return res.status(200).send(body);
   } catch (err) {
     const timedOut = (err as { name?: string })?.name === "AbortError";
     console.error("Etherscan proxy failed", timedOut ? `timed out after ${UPSTREAM_TIMEOUT_MS}ms` : err);
+    // Same reasoning as the non-OK branch: a transient timeout must not be cached.
+    res.setHeader("Cache-Control", "no-store");
     return res.status(timedOut ? 504 : 502).json({
       status: "0",
       message: "NOTOK",

--- a/pages/api/etherscan.ts
+++ b/pages/api/etherscan.ts
@@ -14,6 +14,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY ?? "";
 const ETHERSCAN_V2 = "https://api.etherscan.io/v2/api";
 
+/** How long to wait on Etherscan before giving up and freeing the slot. */
+const UPSTREAM_TIMEOUT_MS = 10_000;
+
 /** `module` → allowed `action`s. Everything else is rejected. */
 const ALLOWED: Record<string, Set<string>> = {
   contract: new Set(["getabi", "getsourcecode"]),
@@ -44,8 +47,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   url.searchParams.set("apikey", ETHERSCAN_API_KEY);
 
+  // Bound the upstream call. Without a deadline a stalled Etherscan response holds this function
+  // open until the platform's own, much longer, timeout — and enough concurrent stalls exhaust the
+  // available concurrency for every other request.
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
   try {
-    const upstream = await fetch(url, { headers: { accept: "application/json" } });
+    const upstream = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
     const body = await upstream.text();
 
     // ABIs are immutable for a given address; let the CDN absorb repeat lookups.
@@ -53,7 +65,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     res.setHeader("Content-Type", "application/json");
     return res.status(upstream.ok ? 200 : 502).send(body);
   } catch (err) {
-    console.error("Etherscan proxy failed", err);
-    return res.status(502).json({ status: "0", message: "NOTOK", result: "Upstream request failed" });
+    const timedOut = (err as { name?: string })?.name === "AbortError";
+    console.error("Etherscan proxy failed", timedOut ? `timed out after ${UPSTREAM_TIMEOUT_MS}ms` : err);
+    return res.status(timedOut ? 504 : 502).json({
+      status: "0",
+      message: "NOTOK",
+      result: timedOut ? "Upstream request timed out" : "Upstream request failed",
+    });
+  } finally {
+    clearTimeout(deadline);
   }
 }

--- a/pages/api/ipfs/pin.ts
+++ b/pages/api/ipfs/pin.ts
@@ -14,6 +14,9 @@ const PINATA_PIN_URL = "https://api.pinata.cloud/pinning/pinFileToIPFS";
 /** Proposal metadata is a small JSON blob; anything larger is not ours. */
 const MAX_BODY_BYTES = 512 * 1024;
 
+/** How long to wait on Pinata before giving up and freeing the slot. */
+const UPSTREAM_TIMEOUT_MS = 15_000;
+
 export const config = {
   api: {
     bodyParser: { sizeLimit: "512kb" },
@@ -47,6 +50,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const fileName = typeof name === "string" ? name.replace(/[^a-zA-Z0-9._-]/g, "").slice(0, 64) : "";
   const safeName = fileName || "metadata.json";
 
+  // Bound the upstream call: a stalled Pinata response would otherwise hold this function open
+  // until the platform timeout, and enough concurrent stalls exhaust the available concurrency.
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+
   try {
     const form = new FormData();
     form.append("file", new Blob([content], { type: "text/plain" }), safeName);
@@ -57,6 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       method: "POST",
       headers: { Authorization: `Bearer ${PINATA_JWT}` },
       body: form,
+      signal: controller.signal,
     });
 
     const data = (await pinRes.json()) as { IpfsHash?: string; error?: unknown };
@@ -69,7 +78,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     return res.status(200).json({ uri: `ipfs://${data.IpfsHash}` });
   } catch (err) {
-    console.error("Pinata pin threw", err);
-    return res.status(502).json({ error: "Could not pin the metadata" });
+    const timedOut = (err as { name?: string })?.name === "AbortError";
+    console.error("Pinata pin threw", timedOut ? `timed out after ${UPSTREAM_TIMEOUT_MS}ms` : err);
+    return res.status(timedOut ? 504 : 502).json({
+      error: timedOut ? "Pinning timed out" : "Could not pin the metadata",
+    });
+  } finally {
+    clearTimeout(deadline);
   }
 }

--- a/plugins/crispVoting/artifacts/CrispVoting.ts
+++ b/plugins/crispVoting/artifacts/CrispVoting.ts
@@ -1,3 +1,6 @@
+// Generated from the CrispVoting build artifact — do not edit by hand.
+// `as const` is load-bearing: without it viem and wagmi fall back to untyped `any` arguments,
+// which is how `uint64` parameters silently accepted JavaScript numbers instead of bigints.
 export const CrispVotingAbi = [
   {
     type: "constructor",
@@ -1300,4 +1303,4 @@ export const CrispVotingAbi = [
     name: "ZeroAddress",
     inputs: [],
   },
-];
+] as const;

--- a/plugins/crispVoting/components/fee/feeEscrowCard.tsx
+++ b/plugins/crispVoting/components/fee/feeEscrowCard.tsx
@@ -22,12 +22,31 @@ function formatAmount(value: bigint, decimals: number): string {
  * button carries the precise shortfall and the withdraw button returns the whole remaining credit.
  */
 export const FeeEscrowCard = ({ quote }: { quote?: ProposalFeeQuote }) => {
-  const { credit, balance, symbol, decimals, isLoading, isBusy, deposit, withdraw } = useFeeEscrow();
+  const { credit, balance, symbol, decimals, isLoading, isBusy, deposit, withdraw, refetch } = useFeeEscrow();
 
-  // Never guess decimals: the fee token is configurable and a wrong exponent would move the
-  // wrong amount by orders of magnitude.
-  if (isLoading || decimals === undefined) {
+  if (isLoading) {
     return <PleaseWaitSpinner fullMessage="Loading the fee credit" />;
+  }
+
+  // Never guess decimals: the fee token is configurable and a wrong exponent would move the wrong
+  // amount by orders of magnitude. But a failed `decimals` read leaves `isLoading` false and
+  // `decimals` undefined, so gating the spinner on both would spin forever with no way out — say
+  // what went wrong and offer a retry instead.
+  if (decimals === undefined) {
+    return (
+      <div className="flex w-full flex-col gap-y-3 rounded-xl border border-neutral-100 bg-neutral-0 p-6 shadow-neutral-sm">
+        <AlertCard
+          variant="critical"
+          message="Could not read the fee token"
+          description="The fee token's decimals could not be loaded, so amounts cannot be shown safely. Check your network connection and the configured fee token address."
+        />
+        <div>
+          <Button size="md" variant="tertiary" onClick={() => refetch()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
   }
 
   const ticker = symbol ?? "tokens";
@@ -80,7 +99,7 @@ export const FeeEscrowCard = ({ quote }: { quote?: ProposalFeeQuote }) => {
       {shortOnBalance && (
         <AlertCard
           variant="critical"
-          message={`You need ${formatAmount(shortfall, decimals)} ${ticker} but hold ${formatAmount(balance ?? 0n, decimals)}`}
+          message={`You need ${formatAmount(shortfall, decimals)} ${ticker} but hold ${formatAmount(balance ?? 0n, decimals)} ${ticker}`}
           description="Use the faucet to get more of the fee token before creating this proposal."
         />
       )}

--- a/plugins/crispVoting/components/fee/refundCard.tsx
+++ b/plugins/crispVoting/components/fee/refundCard.tsx
@@ -12,7 +12,28 @@ import { AddressText } from "@/components/text/address";
  * being pre-empted here.
  */
 export const RefundCard = ({ proposalId }: { proposalId: bigint }) => {
-  const { payer, isSelfPayer, isClaiming, claim } = useClaimRefund(proposalId);
+  const { payer, isSelfPayer, isClaimed, isClaiming, claim } = useClaimRefund(proposalId);
+
+  // A second claim reverts inside the refund manager, so once the on-chain `RefundClaimed` event
+  // exists the action is retired rather than left to fail. `isClaimed` is undefined while the log
+  // query is in flight or after it errored — treated as claimable, since hiding a real refund is
+  // worse than offering one that turns out to be spent.
+  if (isClaimed) {
+    return (
+      <div className="flex w-full flex-col gap-y-3 rounded-xl border border-neutral-100 bg-neutral-0 p-6 shadow-neutral-sm">
+        <AlertCard
+          variant="success"
+          message="This round's fee was refunded"
+          description="The E3 fee has been credited back to the proposal's fee payer, who can withdraw it from the proposal fee credit."
+        />
+        {payer && (
+          <p className="text-sm text-neutral-500">
+            Refunded to {isSelfPayer ? "you" : <AddressText bold={false}>{payer}</AddressText>}.
+          </p>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="flex w-full flex-col gap-y-3 rounded-xl border border-neutral-100 bg-neutral-0 p-6 shadow-neutral-sm">

--- a/plugins/crispVoting/hooks/useCanCreateProposal.ts
+++ b/plugins/crispVoting/hooks/useCanCreateProposal.ts
@@ -42,7 +42,11 @@ export function useCanCreateProposal(): CanCreateProposal {
   const { address } = useAccount();
 
   // Phase 1: read the plugin config (min power + voting token address).
-  const { data: pluginReads, isLoading: pluginLoading } = useReadContracts({
+  const {
+    data: pluginReads,
+    isLoading: pluginLoading,
+    refetch: refetchPlugin,
+  } = useReadContracts({
     contracts: [
       {
         chainId: PUB_CHAIN.id,
@@ -66,7 +70,7 @@ export function useCanCreateProposal(): CanCreateProposal {
   const {
     data: tokenReads,
     isLoading: tokenLoading,
-    refetch,
+    refetch: refetchToken,
   } = useReadContracts({
     query: { enabled: Boolean(address && votingToken) },
     contracts: [
@@ -136,6 +140,14 @@ export function useCanCreateProposal(): CanCreateProposal {
   // The create flow tops the credit up from the wallet balance on demand, so either source is
   // enough — only an account with neither is hard-blocked.
   const hasNoFeeToken = feeBalance !== undefined && feeBalance === 0n && feeCredit !== undefined && feeCredit === 0n;
+
+  // Refresh BOTH batches. Returning only the phase-2 refetch would leave the plugin config
+  // (`minProposerVotingPower`, `getVotingToken`) stale, so a settings change would never be
+  // picked up by a caller that reasonably expects this to resync every eligibility input.
+  const refetch = () => {
+    void refetchPlugin();
+    void refetchToken();
+  };
 
   const canCreate = Boolean(address) && (noThreshold || meetsThreshold) && !hasNoFeeToken;
 

--- a/plugins/crispVoting/hooks/useCanVote.ts
+++ b/plugins/crispVoting/hooks/useCanVote.ts
@@ -1,23 +1,34 @@
-import { useAccount, useBlockNumber, useReadContract } from "wagmi";
-import { CrispVotingAbi } from "../artifacts/CrispVoting";
-import { useEffect } from "react";
-import { PUB_CRISP_VOTING_PLUGIN_ADDRESS } from "@/constants";
+import { useAccount, useReadContract } from "wagmi";
+import { parseAbi } from "viem";
+import { PUB_CHAIN, PUB_TOKEN_ADDRESS } from "@/constants";
 
-export function useCanVote(proposalId: bigint) {
+const erc20Votes = parseAbi(["function getPastVotes(address account, uint256 blockNumber) view returns (uint256)"]);
+
+/**
+ * Whether the connected account could cast a ballot in this round.
+ *
+ * Eligibility is the voting token's delegated power at the proposal's snapshot block — the same
+ * figure the CRISP census is built from. It is deliberately NOT a plugin call: `CrispVoting` has
+ * no `canVote`, and the ballot itself is submitted to the CRISP server rather than the contract.
+ *
+ * Returns `undefined` until the snapshot read resolves, so callers must distinguish "not yet
+ * known" from `false` rather than treating both as ineligible.
+ */
+export function useCanVote(snapshotBlock: bigint | undefined): boolean | undefined {
   const { address } = useAccount();
-  const { data: blockNumber } = useBlockNumber({ watch: true });
 
-  const { data: canVote, refetch: refreshCanVote } = useReadContract({
-    address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
-    abi: CrispVotingAbi,
-    functionName: "canVote",
-    args: [BigInt(proposalId), address!, 1],
-    query: { enabled: !!address },
+  const enabled = Boolean(address) && snapshotBlock !== undefined;
+
+  const { data: pastVotes } = useReadContract({
+    chainId: PUB_CHAIN.id,
+    address: PUB_TOKEN_ADDRESS,
+    abi: erc20Votes,
+    functionName: "getPastVotes",
+    args: [address as `0x${string}`, snapshotBlock ?? 0n],
+    query: { enabled },
   });
 
-  useEffect(() => {
-    refreshCanVote();
-  }, [blockNumber, refreshCanVote]);
+  if (!enabled || pastVotes === undefined) return undefined;
 
-  return canVote;
+  return pastVotes > 0n;
 }

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -5,6 +5,7 @@ import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_DEPLOYMENT_BLOCK } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
 import { awaitSuccessfulReceipt } from "../utils/awaitReceipt";
+import { isRefundQueryStale } from "../utils/refundQuery";
 
 const refundClaimedEvent = parseAbiItem(
   "event RefundClaimed(uint256 indexed proposalId, uint256 indexed e3Id, address indexed payer, uint256 amount)"
@@ -42,21 +43,24 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
   });
 
   /**
-   * Monotonic id for the newest status query. Every `checkClaimed` call claims one and only writes
-   * state if it still holds it — so a `getLogs` for proposal A that lands after the hook moved to
-   * proposal B is discarded rather than shown as B's answer.
+   * Identity of the newest status query, and the proposal currently on screen. `isRefundQueryStale`
+   * checks a finished query against both before it is allowed to write state.
    *
-   * A ref rather than a per-call "is this stale?" argument: the argument form defaults to "never
+   * Refs rather than a per-call "is this stale?" argument: the argument form defaults to "never
    * stale", so any caller that forgets to pass one silently loses the guard — which is exactly how
    * the refresh inside `claim` ended up unprotected.
    */
   const latestQuery = useRef(0);
+  const activeProposalId = useRef<bigint | undefined>(proposalId);
 
   const checkClaimed = useCallback(async () => {
     if (!client || proposalId === undefined) return;
 
-    const query = ++latestQuery.current;
-    const isStale = () => latestQuery.current !== query;
+    // Captured, not read at completion time: this closure belongs to whichever proposal was
+    // current when it was created, which is not necessarily the one on screen when it finishes.
+    const query = { id: ++latestQuery.current, proposalId };
+    const isStale = () =>
+      isRefundQueryStale(query, { latestId: latestQuery.current, activeProposalId: activeProposalId.current });
 
     try {
       const logs = await client.getLogs({
@@ -78,14 +82,15 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
 
   useEffect(() => {
     // Clear the previous proposal's answer immediately. Without this the card would keep showing
-    // proposal A's "already refunded" state while B's query is still in flight. Bumping the id
-    // also retires any in-flight query from the proposal we just left.
+    // proposal A's "already refunded" state while B's query is still in flight. Moving the active
+    // proposal and bumping the id together retires everything issued for the proposal just left.
+    activeProposalId.current = proposalId;
     latestQuery.current += 1;
     setIsClaimed(undefined);
 
     if (!active) return;
     void checkClaimed();
-  }, [active, checkClaimed]);
+  }, [active, proposalId, checkClaimed]);
 
   const { writeContractAsync } = useTransactionManager({
     onSuccessMessage: "Refund claimed",

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -1,9 +1,13 @@
 import { useAccount, usePublicClient, useReadContract } from "wagmi";
-import { useState } from "react";
-import type { Address } from "viem";
+import { useCallback, useEffect, useState } from "react";
+import { parseAbiItem, type Address } from "viem";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
-import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS } from "@/constants";
+import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_DEPLOYMENT_BLOCK } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
+
+const refundClaimedEvent = parseAbiItem(
+  "event RefundClaimed(uint256 indexed proposalId, uint256 indexed e3Id, address indexed payer, uint256 amount)"
+);
 
 /**
  * Claims the requester refund for a proposal whose E3 failed.
@@ -13,11 +17,17 @@ import { useTransactionManager } from "@/hooks/useTransactionManager";
  * nothing by claiming on someone else's behalf. The UI still surfaces who gets the credit, since
  * the person who paid is not necessarily the person looking at the proposal (under the SPP the
  * payer is the parent proposal's creator).
+ *
+ * Whether a refund was already taken has no getter on the plugin — the refund manager owns that
+ * state. The `RefundClaimed` event is the durable record, so it is what decides whether to offer
+ * the button; local state alone would re-offer an already-spent claim after any page reload, and
+ * the second attempt reverts inside the refund manager.
  */
 export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
   const { address } = useAccount();
   const client = usePublicClient();
   const [isClaiming, setIsClaiming] = useState(false);
+  const [isClaimed, setIsClaimed] = useState<boolean | undefined>(undefined);
 
   const active = enabled && proposalId !== undefined;
 
@@ -29,6 +39,30 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
     args: [proposalId ?? 0n],
     query: { enabled: active },
   });
+
+  const checkClaimed = useCallback(async () => {
+    if (!client || proposalId === undefined) return;
+
+    try {
+      const logs = await client.getLogs({
+        address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
+        event: refundClaimedEvent,
+        args: { proposalId },
+        fromBlock: BigInt(PUB_DEPLOYMENT_BLOCK),
+        toBlock: "latest",
+      });
+      setIsClaimed(logs.length > 0);
+    } catch {
+      // Leave `isClaimed` undefined: the card treats "unknown" as claimable rather than hiding a
+      // legitimate refund because a log query failed.
+      setIsClaimed(undefined);
+    }
+  }, [client, proposalId]);
+
+  useEffect(() => {
+    if (!active) return;
+    void checkClaimed();
+  }, [active, checkClaimed]);
 
   const { writeContractAsync } = useTransactionManager({
     onSuccessMessage: "Refund claimed",
@@ -42,6 +76,8 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
 
     try {
       setIsClaiming(true);
+      if (!client) throw new Error("No RPC client available");
+
       const hash = await writeContractAsync({
         chainId: PUB_CHAIN.id,
         abi: CrispVotingAbi,
@@ -49,8 +85,8 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
         functionName: "claimRefund",
         args: [proposalId],
       });
-      await client?.waitForTransactionReceipt({ hash });
-      await refetchPayer();
+      await client.waitForTransactionReceipt({ hash });
+      await Promise.all([refetchPayer(), checkClaimed()]);
     } finally {
       setIsClaiming(false);
     }
@@ -63,6 +99,8 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
     payer: payerAddress,
     /** Whether the connected account is the one that paid for this proposal. */
     isSelfPayer: Boolean(address && payerAddress && address.toLowerCase() === payerAddress.toLowerCase()),
+    /** True once a `RefundClaimed` event exists for this proposal; undefined while unknown. */
+    isClaimed,
     isClaiming,
     claim,
   };

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -4,6 +4,7 @@ import { parseAbiItem, type Address } from "viem";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_DEPLOYMENT_BLOCK } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
+import { awaitSuccessfulReceipt } from "../utils/awaitReceipt";
 
 const refundClaimedEvent = parseAbiItem(
   "event RefundClaimed(uint256 indexed proposalId, uint256 indexed e3Id, address indexed payer, uint256 amount)"
@@ -40,28 +41,48 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
     query: { enabled: active },
   });
 
-  const checkClaimed = useCallback(async () => {
-    if (!client || proposalId === undefined) return;
+  /**
+   * @param isStale Reports whether this query has been superseded. A `getLogs` for proposal A can
+   * land after the hook has moved to proposal B, and writing its result then would show B the
+   * wrong action — so a superseded query discards its result instead of applying it.
+   */
+  const checkClaimed = useCallback(
+    async (isStale: () => boolean = () => false) => {
+      if (!client || proposalId === undefined) return;
 
-    try {
-      const logs = await client.getLogs({
-        address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
-        event: refundClaimedEvent,
-        args: { proposalId },
-        fromBlock: BigInt(PUB_DEPLOYMENT_BLOCK),
-        toBlock: "latest",
-      });
-      setIsClaimed(logs.length > 0);
-    } catch {
-      // Leave `isClaimed` undefined: the card treats "unknown" as claimable rather than hiding a
-      // legitimate refund because a log query failed.
-      setIsClaimed(undefined);
-    }
-  }, [client, proposalId]);
+      try {
+        const logs = await client.getLogs({
+          address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
+          event: refundClaimedEvent,
+          args: { proposalId },
+          fromBlock: BigInt(PUB_DEPLOYMENT_BLOCK),
+          toBlock: "latest",
+        });
+        if (isStale()) return;
+        setIsClaimed(logs.length > 0);
+      } catch {
+        // Leave `isClaimed` undefined: the card treats "unknown" as claimable rather than hiding a
+        // legitimate refund because a log query failed.
+        if (isStale()) return;
+        setIsClaimed(undefined);
+      }
+    },
+    [client, proposalId]
+  );
 
   useEffect(() => {
+    // Clear the previous proposal's answer immediately. Without this the card would keep showing
+    // proposal A's "already refunded" state while B's query is still in flight.
+    setIsClaimed(undefined);
+
     if (!active) return;
-    void checkClaimed();
+
+    let cancelled = false;
+    void checkClaimed(() => cancelled);
+
+    return () => {
+      cancelled = true;
+    };
   }, [active, checkClaimed]);
 
   const { writeContractAsync } = useTransactionManager({
@@ -85,7 +106,7 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
         functionName: "claimRefund",
         args: [proposalId],
       });
-      await client.waitForTransactionReceipt({ hash });
+      await awaitSuccessfulReceipt(client, hash, "The refund claim");
       await Promise.all([refetchPayer(), checkClaimed()]);
     } finally {
       setIsClaiming(false);

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -1,5 +1,5 @@
 import { useAccount, usePublicClient, useReadContract } from "wagmi";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { parseAbiItem, type Address } from "viem";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_DEPLOYMENT_BLOCK } from "@/constants";
@@ -42,47 +42,49 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
   });
 
   /**
-   * @param isStale Reports whether this query has been superseded. A `getLogs` for proposal A can
-   * land after the hook has moved to proposal B, and writing its result then would show B the
-   * wrong action — so a superseded query discards its result instead of applying it.
+   * Monotonic id for the newest status query. Every `checkClaimed` call claims one and only writes
+   * state if it still holds it — so a `getLogs` for proposal A that lands after the hook moved to
+   * proposal B is discarded rather than shown as B's answer.
+   *
+   * A ref rather than a per-call "is this stale?" argument: the argument form defaults to "never
+   * stale", so any caller that forgets to pass one silently loses the guard — which is exactly how
+   * the refresh inside `claim` ended up unprotected.
    */
-  const checkClaimed = useCallback(
-    async (isStale: () => boolean = () => false) => {
-      if (!client || proposalId === undefined) return;
+  const latestQuery = useRef(0);
 
-      try {
-        const logs = await client.getLogs({
-          address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
-          event: refundClaimedEvent,
-          args: { proposalId },
-          fromBlock: BigInt(PUB_DEPLOYMENT_BLOCK),
-          toBlock: "latest",
-        });
-        if (isStale()) return;
-        setIsClaimed(logs.length > 0);
-      } catch {
-        // Leave `isClaimed` undefined: the card treats "unknown" as claimable rather than hiding a
-        // legitimate refund because a log query failed.
-        if (isStale()) return;
-        setIsClaimed(undefined);
-      }
-    },
-    [client, proposalId]
-  );
+  const checkClaimed = useCallback(async () => {
+    if (!client || proposalId === undefined) return;
+
+    const query = ++latestQuery.current;
+    const isStale = () => latestQuery.current !== query;
+
+    try {
+      const logs = await client.getLogs({
+        address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
+        event: refundClaimedEvent,
+        args: { proposalId },
+        fromBlock: BigInt(PUB_DEPLOYMENT_BLOCK),
+        toBlock: "latest",
+      });
+      if (isStale()) return;
+      setIsClaimed(logs.length > 0);
+    } catch {
+      // Leave `isClaimed` undefined: the card treats "unknown" as claimable rather than hiding a
+      // legitimate refund because a log query failed.
+      if (isStale()) return;
+      setIsClaimed(undefined);
+    }
+  }, [client, proposalId]);
 
   useEffect(() => {
     // Clear the previous proposal's answer immediately. Without this the card would keep showing
-    // proposal A's "already refunded" state while B's query is still in flight.
+    // proposal A's "already refunded" state while B's query is still in flight. Bumping the id
+    // also retires any in-flight query from the proposal we just left.
+    latestQuery.current += 1;
     setIsClaimed(undefined);
 
     if (!active) return;
-
-    let cancelled = false;
-    void checkClaimed(() => cancelled);
-
-    return () => {
-      cancelled = true;
-    };
+    void checkClaimed();
   }, [active, checkClaimed]);
 
   const { writeContractAsync } = useTransactionManager({

--- a/plugins/crispVoting/hooks/useCreateProposal.ts
+++ b/plugins/crispVoting/hooks/useCreateProposal.ts
@@ -105,6 +105,16 @@ export function useCreateProposal() {
       });
     }
 
+    // The end date is required: the contract's `_endDate = 0` shorthand means "the earliest date
+    // minDuration allows", which for a plugin configured with minDuration 0 is a vote that closes
+    // in the same block. Demand an explicit, future date rather than silently creating one.
+    if (!Number.isFinite(endDateTime) || endDateTime <= Math.floor(Date.now() / 1000)) {
+      return addAlert("Invalid proposal dates", {
+        description: "Please set an end date in the future",
+        type: "error",
+      });
+    }
+
     for (const item of resources) {
       if (!item.name.trim()) {
         return addAlert("Invalid resource name", {
@@ -138,8 +148,11 @@ export function useCreateProposal() {
       // sending a stale timestamp that is guaranteed to revert.
       const buildArgs = () => {
         const now = Math.floor(Date.now() / 1000);
-        const safeStartDateTime = startDateTime <= now ? 0 : startDateTime;
-        return [toHex(ipfsPin), actions, safeStartDateTime, endDateTime, data] as const;
+        // An empty date field parses to NaN, and `NaN <= now` is false — so a bare comparison
+        // would pass NaN straight through to viem, which cannot encode it as `uint64`. Anything
+        // missing or already past becomes 0, which the contract reads as "start at block.timestamp".
+        const safeStartDateTime = Number.isFinite(startDateTime) && startDateTime > now ? startDateTime : 0;
+        return [toHex(ipfsPin), actions, BigInt(safeStartDateTime), BigInt(endDateTime), data] as const;
       };
 
       // The plugin debits escrowed credit rather than pulling the fee from the caller, so the
@@ -147,8 +160,13 @@ export function useCreateProposal() {
       // the price up front and the escrow panel lets the user deposit it, but this stays as a
       // safety net: an unset start date normalises to `block.timestamp` on-chain, so the window
       // — and the fee — can move between the quote and this transaction.
+      // Not optional-chained on purpose: `client?.simulateContract(...)` resolves to `undefined`
+      // when there is no client, which reads as "the simulation passed" and skips the funding
+      // check entirely — the create transaction would then revert with InsufficientFeeCredit.
+      if (!client) throw new Error("No RPC client available");
+
       const shortfall = await client
-        ?.simulateContract({
+        .simulateContract({
           account: selfAddress,
           abi: CrispVotingAbi,
           address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,

--- a/plugins/crispVoting/hooks/useFeeEscrow.ts
+++ b/plugins/crispVoting/hooks/useFeeEscrow.ts
@@ -1,5 +1,5 @@
 import { useAccount, usePublicClient, useReadContracts } from "wagmi";
-import { erc20Abi, maxUint256, type Address } from "viem";
+import { erc20Abi, type Address } from "viem";
 import { useState } from "react";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_ENCLAVE_FEE_TOKEN_ADDRESS } from "@/constants";
@@ -96,11 +96,22 @@ export function useFeeEscrow(): FeeEscrow {
     onErrorMessage: "Could not withdraw fee credit",
   });
 
+  /**
+   * Optional chaining on `client` would make every await below resolve to `undefined` rather than
+   * fail, silently skipping the receipt waits — the UI would report success and refetch stale
+   * balances while the transactions were still pending.
+   */
+  const requireClient = () => {
+    if (!client) throw new Error("No RPC client available");
+    return client;
+  };
+
   const deposit = async (amount: bigint) => {
     if (amount <= 0n) return;
 
     try {
       setIsBusy(true);
+      const publicClient = requireClient();
       await ensureAllowance(amount);
 
       const hash = await depositWrite({
@@ -110,7 +121,7 @@ export function useFeeEscrow(): FeeEscrow {
         functionName: "deposit",
         args: [amount],
       });
-      await client?.waitForTransactionReceipt({ hash });
+      await publicClient.waitForTransactionReceipt({ hash });
       await refetchReads();
     } finally {
       setIsBusy(false);
@@ -122,6 +133,7 @@ export function useFeeEscrow(): FeeEscrow {
 
     try {
       setIsBusy(true);
+      const publicClient = requireClient();
       const hash = await withdrawWrite({
         chainId: PUB_CHAIN.id,
         abi: CrispVotingAbi,
@@ -129,7 +141,7 @@ export function useFeeEscrow(): FeeEscrow {
         functionName: "withdraw",
         args: [amount],
       });
-      await client?.waitForTransactionReceipt({ hash });
+      await publicClient.waitForTransactionReceipt({ hash });
       await refetchReads();
     } finally {
       setIsBusy(false);
@@ -142,7 +154,9 @@ export function useFeeEscrow(): FeeEscrow {
    * (or missing) approval.
    */
   const ensureAllowance = async (amount: bigint) => {
-    const current = (await client?.readContract({
+    const publicClient = requireClient();
+
+    const current = (await publicClient.readContract({
       address: PUB_ENCLAVE_FEE_TOKEN_ADDRESS,
       abi: erc20Abi,
       functionName: "allowance",
@@ -151,14 +165,18 @@ export function useFeeEscrow(): FeeEscrow {
 
     if ((current ?? 0n) >= amount) return;
 
+    // Exactly `amount`, never an unlimited allowance. The spender is an upgradeable proxy
+    // (`upgradeTo` / `upgradeToAndCall` are in its ABI), so an infinite approval would remain
+    // spendable by whatever implementation sits behind it later. The deposit flow always knows
+    // the precise figure, so the only cost of scoping it is one approval per deposit.
     const hash = await approveWrite({
       chainId: PUB_CHAIN.id,
       abi: erc20Abi,
       address: PUB_ENCLAVE_FEE_TOKEN_ADDRESS,
       functionName: "approve",
-      args: [PUB_CRISP_VOTING_PLUGIN_ADDRESS, maxUint256],
+      args: [PUB_CRISP_VOTING_PLUGIN_ADDRESS, amount],
     });
-    await client?.waitForTransactionReceipt({ hash });
+    await publicClient.waitForTransactionReceipt({ hash });
   };
 
   const decimals = data?.[4]?.result as number | undefined;

--- a/plugins/crispVoting/hooks/useFeeEscrow.ts
+++ b/plugins/crispVoting/hooks/useFeeEscrow.ts
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_ENCLAVE_FEE_TOKEN_ADDRESS } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
+import { awaitSuccessfulReceipt } from "../utils/awaitReceipt";
 
 export type FeeEscrow = {
   /** Fee-token credit escrowed in the plugin for this account (`feeCredits`). */
@@ -121,7 +122,7 @@ export function useFeeEscrow(): FeeEscrow {
         functionName: "deposit",
         args: [amount],
       });
-      await publicClient.waitForTransactionReceipt({ hash });
+      await awaitSuccessfulReceipt(publicClient, hash, "The deposit");
       await refetchReads();
     } finally {
       setIsBusy(false);
@@ -141,7 +142,7 @@ export function useFeeEscrow(): FeeEscrow {
         functionName: "withdraw",
         args: [amount],
       });
-      await publicClient.waitForTransactionReceipt({ hash });
+      await awaitSuccessfulReceipt(publicClient, hash, "The withdrawal");
       await refetchReads();
     } finally {
       setIsBusy(false);
@@ -176,7 +177,8 @@ export function useFeeEscrow(): FeeEscrow {
       functionName: "approve",
       args: [PUB_CRISP_VOTING_PLUGIN_ADDRESS, amount],
     });
-    await publicClient.waitForTransactionReceipt({ hash });
+    // A reverted approval must stop the flow: the deposit that follows would fail anyway.
+    await awaitSuccessfulReceipt(publicClient, hash, "The fee-token approval");
   };
 
   const decimals = data?.[4]?.result as number | undefined;

--- a/plugins/crispVoting/pages/new.tsx
+++ b/plugins/crispVoting/pages/new.tsx
@@ -28,6 +28,7 @@ import { downloadAsFile } from "@/utils/download-as-file";
 import { encodeActionsAsJson } from "@/utils/json-actions";
 import { CreditsMode } from "../utils/types";
 import { FeeEscrowCard } from "../components/fee/feeEscrowCard";
+import { PleaseWaitSpinner } from "@/components/please-wait";
 
 export default function Create() {
   const { address: selfAddress, isConnected } = useAccount();
@@ -126,7 +127,12 @@ export default function Create() {
           </div>
         </div>
 
-        <PlaceHolderOr selfAddress={selfAddress} canCreate={canCreate} isConnected={isConnected}>
+        <PlaceHolderOr
+          selfAddress={selfAddress}
+          canCreate={canCreate}
+          isConnected={isConnected}
+          isLoading={canCreateLoading}
+        >
           <p className="form-intro">
             A proposal becomes <em>active</em> the moment it is mined. Voters then have the window you set to cast
             encrypted ballots — tallies decrypt only once that window closes.
@@ -442,11 +448,10 @@ export default function Create() {
 
           {/* Fee credit */}
 
-          {isConnected && (
-            <div className="mt-8">
-              <FeeEscrowCard quote={feeQuote} />
-            </div>
-          )}
+          {/* No connection guard needed: PlaceHolderOr gates these children on a connected wallet. */}
+          <div className="mt-8">
+            <FeeEscrowCard quote={feeQuote} />
+          </div>
 
           {/* Submit */}
 
@@ -457,15 +462,15 @@ export default function Create() {
               variant="critical"
               message="You cannot create a proposal yet"
               description={
-                !isConnected
-                  ? "Connect your wallet to continue."
-                  : hasNoFeeToken
-                    ? "You have no Interfold fee token and no escrowed fee credit. Creating a proposal pays an E3 fee out of escrowed credit, which is topped up from your balance — use the faucet to get some."
-                    : needsDelegation
-                      ? "You hold enough tokens, but your voting power is 0 because you have never delegated. Token holders have no voting power until they delegate — go to Delegation and delegate to yourself."
-                      : hasNoTokens
-                        ? "You hold none of the voting token, so you have no voting power."
-                        : "Your delegated voting power is below the minimum required to create a proposal."
+                // No `!isConnected` branch: PlaceHolderOr only renders these children once the
+                // wallet is connected, so that case is handled before this card ever mounts.
+                hasNoFeeToken
+                  ? "You have no Interfold fee token and no escrowed fee credit. Creating a proposal pays an E3 fee out of escrowed credit, which is topped up from your balance — use the faucet to get some."
+                  : needsDelegation
+                    ? "You hold enough tokens, but your voting power is 0 because you have never delegated. Token holders have no voting power until they delegate — go to Delegation and delegate to yourself."
+                    : hasNoTokens
+                      ? "You hold none of the voting token, so you have no voting power."
+                      : "Your delegated voting power is below the minimum required to create a proposal."
               }
             />
           )}
@@ -497,11 +502,13 @@ const PlaceHolderOr = ({
   selfAddress,
   isConnected,
   canCreate,
+  isLoading,
   children,
 }: {
   selfAddress: Address | undefined;
   isConnected: boolean;
   canCreate: boolean | undefined;
+  isLoading: boolean;
   children: ReactNode;
 }) => {
   const { open } = useWeb3Modal();
@@ -513,10 +520,18 @@ const PlaceHolderOr = ({
           Please connect your wallet to continue.
         </MissingContentView>
       </Then>
+      {/* `useCanCreateProposal` runs two sequential read batches, and `canCreate` is false for the
+          whole of that. Without this branch the form is replaced by the "cannot create" view on
+          every load, then swapped back — so show it while the answer is still unknown. */}
+      <ElseIf true={isLoading}>
+        <PleaseWaitSpinner fullMessage="Checking whether you can create a proposal" />
+      </ElseIf>
       <ElseIf true={!canCreate}>
-        {/* Not a member */}
+        {/* Ineligible: this plugin gates on delegated voting power and fee funding, not membership.
+            The specific reason is spelled out by the AlertCard inside the form. */}
         <MissingContentView>
-          You cannot create proposals on the multisig because you are not currently defined as a member.
+          You cannot create a proposal yet. Creating one requires delegated voting power above the plugin&apos;s
+          minimum, and enough of the Interfold fee token to cover the encrypted vote round.
         </MissingContentView>
       </ElseIf>
       <Else>{children}</Else>

--- a/plugins/crispVoting/pages/proposal.tsx
+++ b/plugins/crispVoting/pages/proposal.tsx
@@ -107,7 +107,11 @@ export default function ProposalDetail({ index: proposalIdx }: { index: bigint }
                 options={options}
                 disabled={
                   isCommitteeReady === false ||
-                  canVote === false ||
+                  // `canVote !== true`, not `=== false`: it is undefined while the snapshot read
+                  // is pending or after it failed, and an unknown eligibility must not leave the
+                  // action live. The error copy above still keys off a definitive `false`, so an
+                  // in-flight read disables the button without accusing anyone of being ineligible.
+                  canVote !== true ||
                   proposalStatus !== ProposalStatus.ACTIVE ||
                   Number(proposal?.parameters.startDate) > Math.round(Date.now() / 1000)
                 }

--- a/plugins/crispVoting/pages/proposal.tsx
+++ b/plugins/crispVoting/pages/proposal.tsx
@@ -32,7 +32,8 @@ export default function ProposalDetail({ index: proposalIdx }: { index: bigint }
     e3FailureReason,
     status: proposalFetchStatus,
   } = useProposal(proposalIdx);
-  const canVote = useCanVote(proposalIdx);
+  // Eligibility is the token's delegated power at the proposal's snapshot, not a plugin call.
+  const canVote = useCanVote(proposal?.parameters.snapshotBlock);
   const { balance, delegatesTo } = useTokenVotes(address);
 
   const showProposalLoading = getShowProposalLoading(proposal, proposalFetchStatus);

--- a/plugins/crispVoting/utils/awaitReceipt.ts
+++ b/plugins/crispVoting/utils/awaitReceipt.ts
@@ -1,0 +1,23 @@
+import type { Hash, PublicClient } from "viem";
+
+/**
+ * Waits for a transaction and fails if it reverted.
+ *
+ * `waitForTransactionReceipt` RESOLVES for reverted transactions — it only rejects on timeout or
+ * transport failure — so awaiting it bare treats a revert as success. That is how a failed approval
+ * would be followed by a deposit that cannot possibly work, and how a reverted deposit would report
+ * "Fee credit deposited" and refetch an unchanged balance.
+ *
+ * @param client The public client to wait with.
+ * @param hash The transaction to wait for.
+ * @param action Human-readable operation name, used in the thrown message.
+ */
+export async function awaitSuccessfulReceipt(client: PublicClient, hash: Hash, action: string) {
+  const receipt = await client.waitForTransactionReceipt({ hash });
+
+  if (receipt.status !== "success") {
+    throw new Error(`${action} reverted on-chain`);
+  }
+
+  return receipt;
+}

--- a/plugins/crispVoting/utils/feeCredit.ts
+++ b/plugins/crispVoting/utils/feeCredit.ts
@@ -30,7 +30,13 @@ export function readInsufficientFeeCredit(err: unknown): FeeCreditShortfall | un
   if (!(revert instanceof ContractFunctionRevertedError)) return undefined;
   if (revert.data?.errorName !== "InsufficientFeeCredit") return undefined;
 
-  const [payer, required, available] = revert.data.args as readonly [Address, bigint, bigint];
+  // `args` is optional on the decoded data: viem can match the error selector and still fail to
+  // decode the arguments. Destructuring `undefined` would throw a TypeError that replaces the
+  // original revert in the caller's catch block, reporting a decoding bug as a proposal failure.
+  const args = revert.data.args as readonly [Address, bigint, bigint] | undefined;
+  if (!args || args.length < 3) return undefined;
+
+  const [payer, required, available] = args;
 
   return { payer, required, available, missing: required - available };
 }

--- a/plugins/crispVoting/utils/refundQuery.ts
+++ b/plugins/crispVoting/utils/refundQuery.ts
@@ -1,0 +1,30 @@
+/** Identifies one in-flight refund-status query: which proposal it asked about, and when. */
+export type RefundQuery = {
+  /** Monotonic id claimed when the query started. */
+  id: number;
+  /** The proposal the query asked about. */
+  proposalId: bigint;
+};
+
+/** The hook's current position: the newest query id, and the proposal now on screen. */
+export type RefundQueryState = {
+  latestId: number;
+  activeProposalId: bigint | undefined;
+};
+
+/**
+ * Whether a completed refund-status query may still write its result.
+ *
+ * BOTH conditions are load-bearing, and each catches a case the other misses:
+ *
+ * - `id` orders concurrent queries for the SAME proposal, so a slow earlier one cannot overwrite
+ *   a newer answer.
+ * - `proposalId` catches a stale closure that starts a query AFTER the hook has moved on. The
+ *   refresh at the end of `claim` is captured when the hook was on proposal A; if the claim's
+ *   receipt lands once the hook is showing proposal B, that closure queries A's logs and claims a
+ *   brand-new (therefore newest) id. The id check alone would wave it through and paint A's
+ *   answer onto B's UI.
+ */
+export function isRefundQueryStale(query: RefundQuery, state: RefundQueryState): boolean {
+  return query.id !== state.latestId || query.proposalId !== state.activeProposalId;
+}

--- a/plugins/members/hooks/useDelegates.ts
+++ b/plugins/members/hooks/useDelegates.ts
@@ -43,14 +43,28 @@ export function useDelegates() {
         // Falling back to block 0 would scan the entire chain in 9k-block steps — thousands of
         // getLogs calls that leave the directory spinning until the RPC gives up. A missing
         // deployment block is a configuration error, so say so instead of trying.
-        if (!Number.isFinite(PUB_TOKEN_DEPLOYMENT_BLOCK) || PUB_TOKEN_DEPLOYMENT_BLOCK <= 0) {
-          setError("NEXT_PUBLIC_TOKEN_DEPLOYMENT_BLOCK is not configured, so the delegate list cannot be scanned.");
+        //
+        // `isSafeInteger`, not `isFinite`: a fractional value would reach `BigInt()` and throw
+        // (surfacing as the generic "Could not load delegates"), and a value past 2^53 would have
+        // already lost block-number precision by the time it got here.
+        if (!Number.isSafeInteger(PUB_TOKEN_DEPLOYMENT_BLOCK) || PUB_TOKEN_DEPLOYMENT_BLOCK <= 0) {
+          setError("NEXT_PUBLIC_TOKEN_DEPLOYMENT_BLOCK is not a valid block number, so delegates cannot be scanned.");
           setIsLoading(false);
           return;
         }
 
         const latest = await publicClient.getBlockNumber();
         const start = BigInt(PUB_TOKEN_DEPLOYMENT_BLOCK);
+
+        // A deployment block past the chain head skips the loop entirely and renders an empty
+        // directory as though the token simply had no delegates — misconfiguration disguised as data.
+        if (start > latest) {
+          setError(
+            `NEXT_PUBLIC_TOKEN_DEPLOYMENT_BLOCK (${PUB_TOKEN_DEPLOYMENT_BLOCK}) is ahead of the chain head (${latest}).`
+          );
+          setIsLoading(false);
+          return;
+        }
 
         // 1. Collect every address that has ever been delegated to.
         const candidates = new Set<string>();
@@ -72,10 +86,16 @@ export function useDelegates() {
         const addrs = Array.from(candidates) as Address[];
 
         // 2. Read the total supply (for %) and each candidate's current voting power.
+        //
+        // Every read below is pinned to `latest`. Left unpinned they resolve against whatever head
+        // each request happens to hit, so a delegation landing mid-scan could be counted in one
+        // batch and not another — producing percentages that do not sum correctly and a ranking
+        // assembled from two different chain states.
         const supply = (await publicClient.readContract({
           address: PUB_TOKEN_ADDRESS,
           abi: erc20Abi,
           functionName: "totalSupply",
+          blockNumber: latest,
         })) as bigint;
 
         const votes: { result?: unknown }[] = [];
@@ -83,6 +103,7 @@ export function useDelegates() {
           const batch = addrs.slice(i, i + MULTICALL_BATCH);
           const batchVotes = (await publicClient.multicall({
             allowFailure: true,
+            blockNumber: latest,
             contracts: batch.map((a) => ({
               address: PUB_TOKEN_ADDRESS,
               abi: iVotesAbi,

--- a/plugins/members/hooks/useDelegates.ts
+++ b/plugins/members/hooks/useDelegates.ts
@@ -54,6 +54,10 @@ export function useDelegates() {
         }
 
         const latest = await publicClient.getBlockNumber();
+        // The effect can be torn down while this await is pending. Everything past here writes
+        // state, so a superseded run must stop before it overwrites the newer one's results.
+        if (cancelled) return;
+
         const start = BigInt(PUB_TOKEN_DEPLOYMENT_BLOCK);
 
         // A deployment block past the chain head skips the loop entirely and renders an empty

--- a/plugins/members/hooks/useDelegates.ts
+++ b/plugins/members/hooks/useDelegates.ts
@@ -12,6 +12,11 @@ const delegateChangedEvent = parseAbiItem(
 // Keep each getLogs range small enough for public RPCs that cap eth_getLogs.
 const CHUNK = 9_000n;
 
+// The candidate set grows with every address ever delegated to, and a single multicall carrying
+// all of them will eventually exceed an RPC's request, calldata or eth_call limits — at which
+// point the catch below discards the entire directory. Cap how many go into one batch.
+const MULTICALL_BATCH = 200;
+
 export type DelegateEntry = { address: Address; votingPower: bigint };
 
 /**
@@ -35,8 +40,17 @@ export function useDelegates() {
         setIsLoading(true);
         setError(null);
 
+        // Falling back to block 0 would scan the entire chain in 9k-block steps — thousands of
+        // getLogs calls that leave the directory spinning until the RPC gives up. A missing
+        // deployment block is a configuration error, so say so instead of trying.
+        if (!Number.isFinite(PUB_TOKEN_DEPLOYMENT_BLOCK) || PUB_TOKEN_DEPLOYMENT_BLOCK <= 0) {
+          setError("NEXT_PUBLIC_TOKEN_DEPLOYMENT_BLOCK is not configured, so the delegate list cannot be scanned.");
+          setIsLoading(false);
+          return;
+        }
+
         const latest = await publicClient.getBlockNumber();
-        const start = BigInt(PUB_TOKEN_DEPLOYMENT_BLOCK || 0);
+        const start = BigInt(PUB_TOKEN_DEPLOYMENT_BLOCK);
 
         // 1. Collect every address that has ever been delegated to.
         const candidates = new Set<string>();
@@ -64,17 +78,22 @@ export function useDelegates() {
           functionName: "totalSupply",
         })) as bigint;
 
-        const votes = addrs.length
-          ? ((await publicClient.multicall({
-              allowFailure: true,
-              contracts: addrs.map((a) => ({
-                address: PUB_TOKEN_ADDRESS,
-                abi: iVotesAbi,
-                functionName: "getVotes",
-                args: [a],
-              })) as any,
-            })) as { result?: unknown }[])
-          : [];
+        const votes: { result?: unknown }[] = [];
+        for (let i = 0; i < addrs.length; i += MULTICALL_BATCH) {
+          const batch = addrs.slice(i, i + MULTICALL_BATCH);
+          const batchVotes = (await publicClient.multicall({
+            allowFailure: true,
+            contracts: batch.map((a) => ({
+              address: PUB_TOKEN_ADDRESS,
+              abi: iVotesAbi,
+              functionName: "getVotes",
+              args: [a],
+            })) as any,
+          })) as { result?: unknown }[];
+          // Appended in slice order, so `votes[i]` still lines up with `addrs[i]` below.
+          votes.push(...batchVotes);
+          if (cancelled) return;
+        }
         if (cancelled) return;
 
         const entries: DelegateEntry[] = addrs

--- a/tests/etherscan-proxy-query.test.ts
+++ b/tests/etherscan-proxy-query.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, describe } from "bun:test";
 import { whatsabi } from "@shazow/whatsabi";
+import { buildEtherscanUpstreamQuery, type IncomingQuery } from "../utils/etherscan-query";
 
 /**
  * Guards the chainid smuggling in `getEtherscanAbiLoader` (hooks/useAbi.ts).
@@ -43,16 +44,17 @@ async function captureLoaderQuery(apiKey: string): Promise<URLSearchParams> {
   return new URL(captured, "http://localhost").searchParams;
 }
 
-/** What `pages/api/etherscan.ts` forwards upstream, given the caller's query. */
-function proxyForward(incoming: URLSearchParams, serverKey: string): URLSearchParams {
-  const out = new URLSearchParams();
-  for (const [key, value] of incoming.entries()) {
-    if (key === "apikey") continue;
-    out.set(key, value);
-  }
-  out.set("apikey", serverKey);
-  return out;
+/**
+ * Adapts a query string into the `req.query` shape Next hands the route, so the tests can drive
+ * the REAL forwarding helper rather than a copy of it — a duplicate would keep passing while the
+ * route it is supposed to guard broke.
+ */
+function asIncomingQuery(params: URLSearchParams): IncomingQuery {
+  return Object.fromEntries(params.entries());
 }
+
+const proxyForward = (params: URLSearchParams, serverKey: string) =>
+  buildEtherscanUpstreamQuery(asIncomingQuery(params), serverKey);
 
 describe("Etherscan proxy query", () => {
   test("whatsabi splits the smuggled chainid into its own query parameter", async () => {

--- a/tests/etherscan-proxy-query.test.ts
+++ b/tests/etherscan-proxy-query.test.ts
@@ -1,0 +1,86 @@
+import { expect, test, describe } from "bun:test";
+import { whatsabi } from "@shazow/whatsabi";
+
+/**
+ * Guards the chainid smuggling in `getEtherscanAbiLoader` (hooks/useAbi.ts).
+ *
+ * Etherscan's V2 endpoint requires a `chainid` param, but whatsabi 0.14 has no field for one.
+ * The loader rides it in on the `apiKey` value, which whatsabi appends verbatim, so the request
+ * ends up with TWO separate params: `apikey=ignored` and `chainid=<id>`. The `/api/etherscan`
+ * proxy then strips `apikey` (never letting a caller override the server key) and forwards
+ * everything else — `chainid` included.
+ *
+ * That is an unwritten contract across three components. Any of them can break it silently: a
+ * whatsabi version that URL-encodes the apiKey would collapse both params into one useless
+ * `apikey` value, and the upstream request would fail with no chain selected. These tests pin
+ * each half.
+ */
+
+const CHAIN_ID = 11155111;
+const ADDRESS = "0x0000000000000000000000000000000000000001";
+
+/** The query whatsabi actually builds, captured by stubbing fetch. */
+async function captureLoaderQuery(apiKey: string): Promise<URLSearchParams> {
+  const loader = new whatsabi.loaders.EtherscanABILoader({ apiKey, baseURL: "/api/etherscan" });
+
+  let captured = "";
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    captured = typeof input === "string" ? input : input.toString();
+    return new Response(JSON.stringify({ status: "1", result: "[]" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    await loader.loadABI(ADDRESS).catch(() => undefined);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+
+  // The baseURL is relative, so give it an origin purely to parse the query.
+  return new URL(captured, "http://localhost").searchParams;
+}
+
+/** What `pages/api/etherscan.ts` forwards upstream, given the caller's query. */
+function proxyForward(incoming: URLSearchParams, serverKey: string): URLSearchParams {
+  const out = new URLSearchParams();
+  for (const [key, value] of incoming.entries()) {
+    if (key === "apikey") continue;
+    out.set(key, value);
+  }
+  out.set("apikey", serverKey);
+  return out;
+}
+
+describe("Etherscan proxy query", () => {
+  test("whatsabi splits the smuggled chainid into its own query parameter", async () => {
+    const params = await captureLoaderQuery(`ignored&chainid=${CHAIN_ID}`);
+
+    // If whatsabi ever encodes the apiKey, this collapses to one param and the test fails here.
+    expect(params.get("chainid")).toBe(String(CHAIN_ID));
+    expect(params.get("apikey")).toBe("ignored");
+    expect(params.get("action")).toBe("getabi");
+  });
+
+  test("the proxy replaces apikey but preserves chainid", async () => {
+    const params = await captureLoaderQuery(`ignored&chainid=${CHAIN_ID}`);
+    const forwarded = proxyForward(params, "SERVER_KEY");
+
+    expect(forwarded.get("chainid")).toBe(String(CHAIN_ID));
+    expect(forwarded.get("apikey")).toBe("SERVER_KEY");
+  });
+
+  test("a caller cannot override the server key", () => {
+    const incoming = new URLSearchParams({
+      module: "contract",
+      action: "getabi",
+      address: ADDRESS,
+      chainid: String(CHAIN_ID),
+      apikey: "ATTACKER_KEY",
+    });
+
+    expect(proxyForward(incoming, "SERVER_KEY").get("apikey")).toBe("SERVER_KEY");
+  });
+});

--- a/tests/refund-query-staleness.test.ts
+++ b/tests/refund-query-staleness.test.ts
@@ -1,0 +1,92 @@
+import { expect, test, describe } from "bun:test";
+import { isRefundQueryStale, type RefundQueryState } from "../plugins/crispVoting/utils/refundQuery";
+
+/**
+ * The refund card asks "was this proposal's fee already refunded?" by scanning `RefundClaimed`
+ * logs. Those scans are async and the hook can move to a different proposal while one is in flight,
+ * so every finished scan is checked against `isRefundQueryStale` before it writes state.
+ *
+ * These tests drive that rule directly. `useClaimRefund` is a React hook and the repo has no
+ * renderer, so the rule lives in a pure function rather than being untestable inside the hook.
+ */
+
+const A = 1n;
+const B = 2n;
+
+/** Mirrors the hook's two refs. */
+function makeHook() {
+  const state: RefundQueryState = { latestId: 0, activeProposalId: undefined };
+
+  return {
+    state,
+    /** What the effect does when the hook lands on a proposal. */
+    focus(proposalId: bigint) {
+      state.activeProposalId = proposalId;
+      state.latestId += 1;
+    },
+    /** What `checkClaimed` does when it starts a scan. */
+    startQuery(proposalId: bigint) {
+      return { id: ++state.latestId, proposalId };
+    },
+  };
+}
+
+describe("refund status query staleness", () => {
+  test("a scan that completes while its own proposal is still current is applied", () => {
+    const hook = makeHook();
+    hook.focus(A);
+    const query = hook.startQuery(A);
+
+    expect(isRefundQueryStale(query, hook.state)).toBe(false);
+  });
+
+  test("an older scan cannot overwrite a newer one for the same proposal", () => {
+    const hook = makeHook();
+    hook.focus(A);
+    const first = hook.startQuery(A);
+    const second = hook.startQuery(A);
+
+    expect(isRefundQueryStale(first, hook.state)).toBe(true);
+    expect(isRefundQueryStale(second, hook.state)).toBe(false);
+  });
+
+  test("a scan in flight when the hook moves to another proposal is discarded", () => {
+    const hook = makeHook();
+    hook.focus(A);
+    const queryForA = hook.startQuery(A);
+
+    hook.focus(B); // navigated away before A's logs came back
+
+    expect(isRefundQueryStale(queryForA, hook.state)).toBe(true);
+  });
+
+  /**
+   * The case the id counter alone gets wrong, and the reason `proposalId` is checked too.
+   *
+   * `claim()` closes over the proposal that was current when it was called. If its receipt lands
+   * after the hook has moved on, that stale closure starts a BRAND NEW scan — which claims the
+   * newest id and would therefore pass an id-only check, painting proposal A's answer onto B.
+   */
+  test("a claim for A that resolves after moving to B cannot write B's state", () => {
+    const hook = makeHook();
+    hook.focus(A);
+
+    // claim(A) sent; receipt still pending.
+    hook.focus(B); // hook moves to proposal B, which runs its own scan
+    const queryForB = hook.startQuery(B);
+
+    // A's receipt finally lands and the stale closure kicks off its refresh — for A.
+    const lateQueryForA = hook.startQuery(A);
+
+    // It holds the newest id, so an id-only check would accept it.
+    expect(lateQueryForA.id).toBe(hook.state.latestId);
+    expect(lateQueryForA.id !== hook.state.latestId).toBe(false);
+
+    // The proposal check is what rejects it.
+    expect(isRefundQueryStale(lateQueryForA, hook.state)).toBe(true);
+
+    // ...and B's own scan is superseded by that late request's id bump, so it is dropped too:
+    // neither writes state, leaving `isClaimed` undefined, which the card treats as claimable.
+    expect(isRefundQueryStale(queryForB, hook.state)).toBe(true);
+  });
+});

--- a/utils/etherscan-query.ts
+++ b/utils/etherscan-query.ts
@@ -1,0 +1,31 @@
+/** The query shape Next gives an API route (`req.query`). */
+export type IncomingQuery = Record<string, string | string[] | undefined>;
+
+/**
+ * Builds the query the Etherscan proxy forwards upstream.
+ *
+ * Two rules, both load-bearing:
+ *
+ * 1. A caller-supplied `apikey` is always dropped and replaced with the server key, so the route
+ *    cannot be used to smuggle in someone else's key or to read ours back.
+ * 2. Everything else is forwarded verbatim — in particular `chainid`, which `getEtherscanAbiLoader`
+ *    (hooks/useAbi.ts) smuggles through whatsabi's `apiKey` field because whatsabi 0.14 has no
+ *    chainid option. Dropping it would send a chainless request to the V2 endpoint.
+ *
+ * Lives here rather than inline in the route so the tests exercise the real implementation.
+ */
+export function buildEtherscanUpstreamQuery(incoming: IncomingQuery, serverKey: string): URLSearchParams {
+  const out = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(incoming)) {
+    // Belt and braces. What actually guarantees rule 1 is the `set` below overwriting any
+    // caller-supplied value; this skip keeps that true if the loop ever moves to `append`, where
+    // both values would survive and the caller's would be sent first.
+    if (key === "apikey") continue;
+    out.set(key, Array.isArray(value) ? (value[0] ?? "") : String(value ?? ""));
+  }
+
+  out.set("apikey", serverKey);
+
+  return out;
+}


### PR DESCRIPTION
Follow-up to #79, which was merged before its review was addressed. Each finding was verified against the current code before being actioned — two turned out to describe the symptom inaccurately, noted below.

## Correctness

**`buildArgs` could send `NaN` dates** (flagged Critical, confirmed). An empty date field parses to `NaN`, and `NaN <= now` is `false`, so the existing guard passed it straight to viem, which cannot encode `NaN` as `uint64`. The quote path already guarded this; the submit path did not. Also now requires an explicit future end date rather than leaning on the contract's `0` shorthand, which under `minDuration: 0` would open and close a vote in the same block.

**`useCanVote` called a function that does not exist.** Not in the review — `as const` on the ABI surfaced it. The hook read `canVote` from `CrispVoting`, which has no such function, so the call always reverted and `canVote` was permanently `undefined`. Both consumers compare `canVote === false`, which was therefore never true: the vote-eligibility gate on the proposal page has never done anything. Reimplemented as delegated voting power at the proposal's snapshot block, which is the same basis the CRISP census uses.

**Repeat refund claims.** A second `claimRefund` reverts inside the refund manager. There is no refund-status getter, so the card now derives state from the durable `RefundClaimed` event; local state alone would re-offer a spent claim after any reload. An unknown result (query still running, or failed) is treated as claimable — hiding a real refund is the worse error.

**`readInsufficientFeeCredit` destructured optional `args`.** A decode failure would throw a `TypeError` that replaces the original revert in the caller's catch, reporting a decode bug as a proposal failure.

**`refetch` refreshed only one batch**, leaving `minProposerVotingPower` and `getVotingToken` stale.

## Stability

**Unbounded upstream requests.** Both API proxies now use an `AbortController` deadline cleared in `finally`, returning 504 on timeout (Etherscan 10s, Pinata 15s).

**Optional-chained public client.** `client?.waitForTransactionReceipt(...)` resolves to `undefined` rather than failing, so receipt waits and the fee preflight were skipped silently — the UI would report success while transactions were still pending, and the create could run against unfunded credit. Both hooks now throw.

**Permanent spinner.** A failed `decimals` read leaves `isLoading` false and `decimals` undefined, so the escrow card spun forever. Now renders an error with a retry.

**`useDelegates`.** An unset deployment block fell back to block 0 and scanned all history in 9k-block steps; now reported as a configuration error. The multicall is chunked at 200 — note the finding said it "sends one multicall for every candidate", which was wrong (it was one multicall containing every candidate), but the underlying risk of exceeding RPC limits was real.

## Security

**`ensureAllowance` granted `maxUint256`.** The spender is an upgradeable proxy exposing `upgradeTo` / `upgradeToAndCall`, so an unlimited allowance stays spendable by whatever implementation replaces it. The deposit flow always knows the exact figure, so it now approves precisely that.

## Types and copy

`CrispVotingAbi` is exported `as const` (the generator writes it that way, so regeneration keeps it) and `createProposal` receives `bigint` dates. `PlaceHolderOr` no longer hides the form during the two eligibility read batches, and no longer tells users this is a multisig membership check. Removed the `!isConnected` branches that `PlaceHolderOr` makes unreachable, and added the missing ticker to the shortfall message.

## Tests

`tests/etherscan-proxy-query.test.ts` pins the `chainid` smuggling: whatsabi 0.14 appends `apiKey` verbatim, so `chainid` arrives as its own parameter, and the proxy strips `apikey` while preserving it. It stubs `fetch` to capture the URL whatsabi really builds, so a version that starts encoding the value fails the test rather than silently sending a chainless request. Also asserts a caller cannot override the server key.

## Not addressed

**Rate limiting and scoped authorization on the credential-backed proxies.** The concern is legitimate: `/api/ipfs/pin` lets anyone pin ≤512KB using the Pinata account, and `/api/etherscan` lets anyone burn the key quota. Hiding the credential does not limit the capability.

This is not a code tweak. Effective rate limiting on serverless needs a shared store (Vercel KV / Upstash) — an in-memory counter is per-instance and would give false confidence. Scoping uploads to one proposal needs an auth scheme, most plausibly a signed message from an address holding voting power, checked server-side. Both are design decisions with infrastructure implications, so they are left for a separate change rather than being half-done here.

## Verification

`tsc` clean, eslint 0 errors, `next build` compiles, new tests pass. The four pre-existing test failures (libsodium module resolution, a stale `optimistic-proposals` import) are identical on `main`.

Not verified in a browser — the Chrome extension is not connected in this environment, so the UI changes are checked at the type and build level only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added clear timeout handling for blockchain and IPFS requests.
  - Improved refund status displays after a refund has already been claimed.
  - Added retry handling when token details fail to load.
  - Voting eligibility now reflects delegated voting power at the proposal snapshot.
  - Improved proposal date validation, fee-credit handling, and delegate lookups.
  - Corrected transaction failure handling and Etherscan query forwarding.

- **User Experience**
  - Added loading states and clearer proposal eligibility guidance.
  - Fee approvals now request only the required amount.
  - Proposal refresh actions update all relevant information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->