### PR TITLE
chore: add refunds and failures

### DIFF
--- a/plugins/crispVoting/components/fee/feeEscrowCard.tsx
+++ b/plugins/crispVoting/components/fee/feeEscrowCard.tsx
@@ -22,7 +22,7 @@ function formatAmount(value: bigint, decimals: number): string {
  * button carries the precise shortfall and the withdraw button returns the whole remaining credit.
  */
 export const FeeEscrowCard = ({ quote }: { quote?: ProposalFeeQuote }) => {
-  const { credit, balance, symbol, decimals, isLoading, isBusy, deposit, withdraw, refetch } = useFeeEscrow();
+  const { credit, balance, symbol, decimals, isLoading, isBusy, error, deposit, withdraw, refetch } = useFeeEscrow();
 
   if (isLoading) {
     return <PleaseWaitSpinner fullMessage="Loading the fee credit" />;
@@ -111,6 +111,11 @@ export const FeeEscrowCard = ({ quote }: { quote?: ProposalFeeQuote }) => {
           description="No deposit needed — creating the proposal will debit the fee from your credit."
         />
       )}
+
+      {/* Deposits and withdrawals can fail where the transaction manager never sees it — the
+          client guard throws before anything is sent, and a reverted receipt is caught by
+          `awaitSuccessfulReceipt` rather than by wagmi. */}
+      {error && <AlertCard variant="critical" message="Transaction failed" description={error} />}
 
       <div className="flex flex-wrap gap-3">
         {/* The exact shortfall, not the full fee: credit left over from an earlier proposal or

--- a/plugins/crispVoting/components/fee/refundCard.tsx
+++ b/plugins/crispVoting/components/fee/refundCard.tsx
@@ -25,8 +25,19 @@ const Step = ({ done, children }: { done: boolean; children: React.ReactNode }) 
 );
 
 export const RefundCard = ({ proposalId, e3Id }: { proposalId: bigint; e3Id: bigint }) => {
-  const { payer, isSelfPayer, isClaimed, isMarkedFailed, isCalculated, refundAmount, pendingSteps, isClaiming, claim } =
-    useClaimRefund(proposalId, e3Id);
+  const {
+    payer,
+    isSelfPayer,
+    isClaimed,
+    isMarkedFailed,
+    isCalculated,
+    refundAmount,
+    pendingSteps,
+    error,
+    isReady,
+    isClaiming,
+    claim,
+  } = useClaimRefund(proposalId, e3Id);
   const { symbol, decimals } = useFeeEscrow();
 
   // A second claim reverts inside the refund manager, so once the on-chain `RefundClaimed` event
@@ -83,8 +94,24 @@ export const RefundCard = ({ proposalId, e3Id }: { proposalId: bigint; e3Id: big
           : "Requires one transaction."}
       </p>
 
+      {/* Settlement failures surface here rather than only in the console: several of them
+          (preflight, reverted receipt) never reach the transaction manager's alerts. */}
+      {error && (
+        <AlertCard
+          variant="critical"
+          message="Could not settle the refund"
+          description={`${error} Any steps that already completed are kept — retrying resumes from there.`}
+        />
+      )}
+
       <div>
-        <Button size="md" variant="secondary" isLoading={isClaiming} disabled={isClaiming} onClick={() => void claim()}>
+        <Button
+          size="md"
+          variant="secondary"
+          isLoading={isClaiming}
+          disabled={isClaiming || !isReady}
+          onClick={() => void claim()}
+        >
           {isMarkedFailed ? "Settle refund" : "Mark failed and refund"}
         </Button>
       </div>

--- a/plugins/crispVoting/components/fee/refundCard.tsx
+++ b/plugins/crispVoting/components/fee/refundCard.tsx
@@ -74,11 +74,15 @@ export const RefundCard = ({ proposalId, e3Id }: { proposalId: bigint; e3Id: big
         description="The encrypted vote round could not complete, so Interfold refunds the fee it was paid. Settling it credits the fee back to whoever paid for this proposal."
       />
 
-      <ul className="flex flex-col gap-y-1">
-        <Step done={isMarkedFailed}>Record the failure on-chain</Step>
-        <Step done={isCalculated}>Calculate the refund</Step>
-        <Step done={false}>Credit it to the fee payer</Step>
-      </ul>
+      {/* Same reason as the transaction count: an unresolved read is indistinguishable from an
+          outstanding step, so ticks would flicker on as the reads land. */}
+      {isReady && (
+        <ul className="flex flex-col gap-y-1">
+          <Step done={isMarkedFailed}>Record the failure on-chain</Step>
+          <Step done={isCalculated}>Calculate the refund</Step>
+          <Step done={false}>Credit it to the fee payer</Step>
+        </ul>
+      )}
 
       {amountLabel && <p className="text-sm text-neutral-500">Refund: {amountLabel}.</p>}
 
@@ -88,10 +92,14 @@ export const RefundCard = ({ proposalId, e3Id }: { proposalId: bigint; e3Id: big
         </p>
       )}
 
+      {/* Held back until the reads resolve: `pendingSteps` counts an unresolved step as
+          outstanding, so showing it early claims more transactions than are actually needed. */}
       <p className="text-sm text-neutral-500">
-        {pendingSteps > 1
-          ? `Requires ${pendingSteps} transactions — none of these steps happen automatically.`
-          : "Requires one transaction."}
+        {!isReady
+          ? "Checking what still needs to happen…"
+          : pendingSteps > 1
+            ? `Requires ${pendingSteps} transactions — none of these steps happen automatically.`
+            : "Requires one transaction."}
       </p>
 
       {/* Settlement failures surface here rather than only in the console: several of them
@@ -112,7 +120,7 @@ export const RefundCard = ({ proposalId, e3Id }: { proposalId: bigint; e3Id: big
           disabled={isClaiming || !isReady}
           onClick={() => void claim()}
         >
-          {isMarkedFailed ? "Settle refund" : "Mark failed and refund"}
+          {!isReady ? "Checking…" : isMarkedFailed ? "Settle refund" : "Mark failed and refund"}
         </Button>
       </div>
     </div>

--- a/plugins/crispVoting/components/fee/refundCard.tsx
+++ b/plugins/crispVoting/components/fee/refundCard.tsx
@@ -1,18 +1,33 @@
 import { AlertCard, Button } from "@aragon/ods";
+import { formatUnits } from "viem";
 import { useClaimRefund } from "../../hooks/useClaimRefund";
+import { useFeeEscrow } from "../../hooks/useFeeEscrow";
 import { AddressText } from "@/components/text/address";
 
 /**
- * Offered when a proposal's E3 round failed: the fee paid to Interfold is refundable, and the
- * plugin routes the claim straight back to the recorded fee payer's escrowed credit.
+ * Offered when a proposal's E3 round has died: the fee paid to Interfold is refundable, and the
+ * plugin routes the claim back to the recorded fee payer's escrowed credit.
  *
- * The button is shown to anyone — the claim is permissionless and can only ever credit the payer,
- * so a bystander triggering it is a favour, not a risk. Double-claims are rejected by the refund
- * manager, which is why a failed claim surfaces as an ordinary transaction error rather than
- * being pre-empted here.
+ * Getting there takes up to three permissionless transactions, because Interfold does not fail or
+ * settle a round on its own — see `useClaimRefund`. The card shows which of them are outstanding
+ * rather than offering a single "Claim" that reverts with `RefundNotCalculated`.
+ *
+ * The action is shown to anyone: every step only ever moves funds to the recorded payer, so a
+ * bystander running it is doing the payer a favour, not taking anything.
  */
-export const RefundCard = ({ proposalId }: { proposalId: bigint }) => {
-  const { payer, isSelfPayer, isClaimed, isClaiming, claim } = useClaimRefund(proposalId);
+const Step = ({ done, children }: { done: boolean; children: React.ReactNode }) => (
+  <li className="flex items-center gap-x-2 text-sm">
+    <span aria-hidden="true" className={done ? "text-success-600" : "text-neutral-400"}>
+      {done ? "✓" : "○"}
+    </span>
+    <span className={done ? "text-neutral-500 line-through" : "text-neutral-800"}>{children}</span>
+  </li>
+);
+
+export const RefundCard = ({ proposalId, e3Id }: { proposalId: bigint; e3Id: bigint }) => {
+  const { payer, isSelfPayer, isClaimed, isMarkedFailed, isCalculated, refundAmount, pendingSteps, isClaiming, claim } =
+    useClaimRefund(proposalId, e3Id);
+  const { symbol, decimals } = useFeeEscrow();
 
   // A second claim reverts inside the refund manager, so once the on-chain `RefundClaimed` event
   // exists the action is retired rather than left to fail. `isClaimed` is undefined while the log
@@ -35,21 +50,44 @@ export const RefundCard = ({ proposalId }: { proposalId: bigint }) => {
     );
   }
 
+  const amountLabel =
+    refundAmount !== undefined && refundAmount > 0n && decimals !== undefined
+      ? `${formatUnits(refundAmount, decimals)} ${symbol ?? ""}`.trim()
+      : null;
+
   return (
     <div className="flex w-full flex-col gap-y-3 rounded-xl border border-neutral-100 bg-neutral-0 p-6 shadow-neutral-sm">
       <AlertCard
         variant="info"
         message="This round's fee is refundable"
-        description="The encrypted vote round failed, so Interfold refunds the fee it was paid. Claiming credits it back to whoever paid for this proposal."
+        description="The encrypted vote round could not complete, so Interfold refunds the fee it was paid. Settling it credits the fee back to whoever paid for this proposal."
       />
+
+      <ul className="flex flex-col gap-y-1">
+        <Step done={isMarkedFailed}>Record the failure on-chain</Step>
+        <Step done={isCalculated}>Calculate the refund</Step>
+        <Step done={false}>Credit it to the fee payer</Step>
+      </ul>
+
+      {amountLabel && <p className="text-sm text-neutral-500">Refund: {amountLabel}.</p>}
+
       {payer && (
         <p className="text-sm text-neutral-500">
-          Refund goes to {isSelfPayer ? "you" : <AddressText bold={false}>{payer}</AddressText>}.
+          Goes to {isSelfPayer ? "you" : <AddressText bold={false}>{payer}</AddressText>}.
         </p>
       )}
-      <Button size="md" variant="secondary" isLoading={isClaiming} disabled={isClaiming} onClick={() => void claim()}>
-        Claim refund
-      </Button>
+
+      <p className="text-sm text-neutral-500">
+        {pendingSteps > 1
+          ? `Requires ${pendingSteps} transactions — none of these steps happen automatically.`
+          : "Requires one transaction."}
+      </p>
+
+      <div>
+        <Button size="md" variant="secondary" isLoading={isClaiming} disabled={isClaiming} onClick={() => void claim()}>
+          {isMarkedFailed ? "Settle refund" : "Mark failed and refund"}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/plugins/crispVoting/components/proposal/header.tsx
+++ b/plugins/crispVoting/components/proposal/header.tsx
@@ -25,7 +25,8 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = ({ proposalIdx, proposal, 
   const endDateIsInThePast = Number(proposal.parameters.endDate) * 1000 < Date.now();
 
   let endLabel: string;
-  if (proposalStatus === ProposalStatus.ACCEPTED) endLabel = "Accepted";
+  if (e3Failed) endLabel = "Round failed";
+  else if (proposalStatus === ProposalStatus.ACCEPTED) endLabel = "Accepted";
   else if (proposalStatus === ProposalStatus.REJECTED) endLabel = "Rejected";
   else if (endDateIsInThePast) endLabel = "Voting closed";
   else endLabel = `Ends in ${countdown}`;
@@ -45,6 +46,9 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = ({ proposalIdx, proposal, 
         <div className="flex w-full flex-col">
           <div className="flex flex-wrap items-center gap-3">
             {proposalStatus && <span className={`badge ${statusClass}`}>{capitalizeFirstLetter(proposalStatus)}</span>}
+            {/* "Rejected" on its own reads as "the DAO voted this down". A failed round was never
+                decided at all — the encrypted vote could not complete. */}
+            {e3Failed && <span className="badge failed">Round failed</span>}
             {isEmergency && <span className="badge failed">Emergency</span>}
           </div>
           <h1 className="detail-title">{proposal.title || DEFAULT_PROPOSAL_TITLE}</h1>

--- a/plugins/crispVoting/components/proposal/index.tsx
+++ b/plugins/crispVoting/components/proposal/index.tsx
@@ -71,6 +71,9 @@ export default function ProposalCard(props: ProposalInputs) {
       <div className="body">
         <div className="meta">
           <span className={`badge ${statusClass}`}>{capitalize(proposalStatus)}</span>
+          {/* A failed round and a voted-down proposal both resolve to REJECTED, but they mean
+              very different things — one was decided, the other never got to run. Say which. */}
+          {e3Failed && <span className="badge failed">Round failed</span>}
         </div>
         <h3>{proposal!.title}</h3>
         <p className="summary line-clamp-2">{proposal!.summary}</p>

--- a/plugins/crispVoting/components/vote/voteResultCard.tsx
+++ b/plugins/crispVoting/components/vote/voteResultCard.tsx
@@ -33,6 +33,8 @@ interface VoteResultCardProps {
   e3Failed?: boolean;
   /** The on-chain failure reason, when `e3Failed` is set. */
   e3FailureReason?: E3FailureReason;
+  /** The round meets the failure condition but nobody has sent `markE3Failed` yet. */
+  e3FailurePending?: boolean;
 }
 
 // Interfold earth-tone palette — matches the vote card option colors
@@ -101,6 +103,7 @@ export const VoteResultCard = ({
   creditMode,
   e3Failed,
   e3FailureReason,
+  e3FailurePending,
 }: VoteResultCardProps) => {
   const { executeProposal, canExecute, isConfirming: isConfirmingExecution } = useProposalExecute(proposalId);
   const { decimals, symbol } = useToken();
@@ -161,7 +164,7 @@ export const VoteResultCard = ({
         <div className="vp-head">
           <h3>Result</h3>
           <span className="vp-meta" style={{ color: "var(--critical, #a84932)" }}>
-            Rejected
+            Round failed
           </span>
         </div>
         <div className="vp-body items-center text-center">
@@ -175,6 +178,14 @@ export const VoteResultCard = ({
           <p className="vp-note text-center">
             {describeE3Failure(e3FailureReason)} This proposal could not be tallied or executed.
           </p>
+          {/* Interfold does not fail a round by itself — `markE3Failed` is a permissionless call
+              someone has to send once the deadline passes. Until then the round still reads as
+              live on-chain, and the refund cannot be claimed. */}
+          {e3FailurePending && (
+            <p className="vp-note text-center">
+              The failure has not been recorded on-chain yet. Anyone can finalise it, which also unlocks the fee refund.
+            </p>
+          )}
         </div>
       </div>
     );

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -1,37 +1,58 @@
 import { useAccount, usePublicClient, useReadContract } from "wagmi";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { parseAbiItem, type Address } from "viem";
+import { parseAbi, parseAbiItem, type Address } from "viem";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_DEPLOYMENT_BLOCK } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
 import { awaitSuccessfulReceipt } from "../utils/awaitReceipt";
 import { isRefundQueryStale } from "../utils/refundQuery";
+import { E3Stage } from "./useE3Status";
 
 const refundClaimedEvent = parseAbiItem(
   "event RefundClaimed(uint256 indexed proposalId, uint256 indexed e3Id, address indexed payer, uint256 amount)"
 );
 
+const pluginAbi = parseAbi(["function interfold() view returns (address)"]);
+
+const interfoldAbi = parseAbi([
+  "function getE3Stage(uint256 e3Id) view returns (uint8)",
+  "function e3RefundManager() view returns (address)",
+  "function markE3Failed(uint256 e3Id) returns (uint8)",
+  "function processE3Failure(uint256 e3Id)",
+]);
+
+const refundManagerAbi = parseAbi([
+  "struct RefundDistribution { uint256 requesterAmount; uint256 honestNodeAmount; uint256 protocolAmount; uint256 totalSlashed; uint256 honestNodeCount; bool calculated; address feeToken; uint256 originalPayment; uint256 perNodeAmount; }",
+  "function getRefundDistribution(uint256 e3Id) view returns (RefundDistribution)",
+]);
+
 /**
  * Claims the requester refund for a proposal whose E3 failed.
  *
- * `claimRefund` is permissionless on purpose — the refund manager only ever pays the requester
- * (the plugin), and the plugin credits it to the recorded `proposalPayer`, so the caller gains
- * nothing by claiming on someone else's behalf. The UI still surfaces who gets the credit, since
- * the person who paid is not necessarily the person looking at the proposal (under the SPP the
- * payer is the parent proposal's creator).
+ * Claiming is the LAST of three steps, and the first two are what make it work:
  *
- * Whether a refund was already taken has no getter on the plugin — the refund manager owns that
- * state. The `RefundClaimed` event is the durable record, so it is what decides whether to offer
- * the button; local state alone would re-offer an already-spent claim after any page reload, and
- * the second attempt reverts inside the refund manager.
+ *   1. `markE3Failed(e3Id)` moves the round from its stalled stage into `Failed`. Interfold never
+ *      does this itself — it is a permissionless call someone must send once a stage deadline
+ *      passes, so a round whose DKG timed out days ago still reads as live until then.
+ *   2. `processE3Failure(e3Id)` transfers the payment to the refund manager and calculates the
+ *      distribution. Without it `claimRequesterRefund` reverts with `RefundNotCalculated`.
+ *   3. `claimRefund(proposalId)` on the plugin, which credits the recorded `proposalPayer`.
+ *
+ * The plugin's `claimRefund` forwards straight to the refund manager with no preconditions of its
+ * own, so offering step 3 alone reverts on any round that has not been through 1 and 2. This hook
+ * runs whichever steps are still outstanding.
+ *
+ * Step 3 is permissionless by design — the refund manager only ever pays the requester (the
+ * plugin), and the plugin credits the recorded payer — so the caller gains nothing by claiming on
+ * someone else's behalf. Steps 1 and 2 are permissionless in Interfold for the same reason.
  */
-export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
+export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | undefined, enabled = true) {
   const { address } = useAccount();
   const client = usePublicClient();
   const [isClaiming, setIsClaiming] = useState(false);
   const [isClaimed, setIsClaimed] = useState<boolean | undefined>(undefined);
 
-  const active = enabled && proposalId !== undefined;
+  const active = enabled && proposalId !== undefined && e3Id !== undefined;
 
   const { data: payer, refetch: refetchPayer } = useReadContract({
     chainId: PUB_CHAIN.id,
@@ -42,13 +63,49 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
     query: { enabled: active },
   });
 
+  const { data: interfold } = useReadContract({
+    chainId: PUB_CHAIN.id,
+    address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
+    abi: pluginAbi,
+    functionName: "interfold",
+    query: { enabled: active },
+  });
+
+  const interfoldAddress = interfold as Address | undefined;
+
+  const { data: stageRaw, refetch: refetchStage } = useReadContract({
+    chainId: PUB_CHAIN.id,
+    address: interfoldAddress,
+    abi: interfoldAbi,
+    functionName: "getE3Stage",
+    args: [e3Id ?? 0n],
+    query: { enabled: active && !!interfoldAddress },
+  });
+
+  const { data: refundManager } = useReadContract({
+    chainId: PUB_CHAIN.id,
+    address: interfoldAddress,
+    abi: interfoldAbi,
+    functionName: "e3RefundManager",
+    query: { enabled: active && !!interfoldAddress },
+  });
+
+  const { data: distribution, refetch: refetchDistribution } = useReadContract({
+    chainId: PUB_CHAIN.id,
+    address: refundManager as Address | undefined,
+    abi: refundManagerAbi,
+    functionName: "getRefundDistribution",
+    args: [e3Id ?? 0n],
+    query: { enabled: active && !!refundManager },
+  });
+
+  const isMarkedFailed = stageRaw !== undefined && Number(stageRaw) === E3Stage.Failed;
+  const isCalculated = (distribution as { calculated?: boolean } | undefined)?.calculated === true;
+  const refundAmount = (distribution as { requesterAmount?: bigint } | undefined)?.requesterAmount;
+
   /**
-   * Identity of the newest status query, and the proposal currently on screen. `isRefundQueryStale`
-   * checks a finished query against both before it is allowed to write state.
-   *
-   * Refs rather than a per-call "is this stale?" argument: the argument form defaults to "never
-   * stale", so any caller that forgets to pass one silently loses the guard — which is exactly how
-   * the refresh inside `claim` ended up unprotected.
+   * Identity of the newest status query, and the proposal currently on screen.
+   * See `isRefundQueryStale` for why both are checked.
    */
   const latestQuery = useRef(0);
   const activeProposalId = useRef<bigint | undefined>(proposalId);
@@ -56,8 +113,6 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
   const checkClaimed = useCallback(async () => {
     if (!client || proposalId === undefined) return;
 
-    // Captured, not read at completion time: this closure belongs to whichever proposal was
-    // current when it was created, which is not necessarily the one on screen when it finishes.
     const query = { id: ++latestQuery.current, proposalId };
     const isStale = () =>
       isRefundQueryStale(query, { latestId: latestQuery.current, activeProposalId: activeProposalId.current });
@@ -81,9 +136,6 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
   }, [client, proposalId]);
 
   useEffect(() => {
-    // Clear the previous proposal's answer immediately. Without this the card would keep showing
-    // proposal A's "already refunded" state while B's query is still in flight. Moving the active
-    // proposal and bumping the id together retires everything issued for the proposal just left.
     activeProposalId.current = proposalId;
     latestQuery.current += 1;
     setIsClaimed(undefined);
@@ -92,21 +144,55 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
     void checkClaimed();
   }, [active, proposalId, checkClaimed]);
 
-  const { writeContractAsync } = useTransactionManager({
+  const { writeContractAsync: markFailedWrite } = useTransactionManager({
+    onSuccessMessage: "Round marked as failed",
+    onErrorMessage: "Could not mark the round as failed",
+  });
+
+  const { writeContractAsync: processFailureWrite } = useTransactionManager({
+    onSuccessMessage: "Refund calculated",
+    onErrorMessage: "Could not calculate the refund",
+  });
+
+  const { writeContractAsync: claimWrite } = useTransactionManager({
     onSuccessMessage: "Refund claimed",
     onSuccessDescription: "The E3 fee has been credited back to the proposal's fee payer",
     onErrorMessage: "Could not claim the refund",
-    onError: () => setIsClaiming(false),
   });
 
   const claim = async () => {
-    if (proposalId === undefined) return;
+    if (proposalId === undefined || e3Id === undefined) return;
 
     try {
       setIsClaiming(true);
       if (!client) throw new Error("No RPC client available");
+      if (!interfoldAddress) throw new Error("Interfold address unavailable");
 
-      const hash = await writeContractAsync({
+      if (!isMarkedFailed) {
+        const hash = await markFailedWrite({
+          chainId: PUB_CHAIN.id,
+          abi: interfoldAbi,
+          address: interfoldAddress,
+          functionName: "markE3Failed",
+          args: [e3Id],
+        });
+        await awaitSuccessfulReceipt(client, hash, "Marking the round as failed");
+        await refetchStage();
+      }
+
+      if (!isCalculated) {
+        const hash = await processFailureWrite({
+          chainId: PUB_CHAIN.id,
+          abi: interfoldAbi,
+          address: interfoldAddress,
+          functionName: "processE3Failure",
+          args: [e3Id],
+        });
+        await awaitSuccessfulReceipt(client, hash, "Calculating the refund");
+        await refetchDistribution();
+      }
+
+      const hash = await claimWrite({
         chainId: PUB_CHAIN.id,
         abi: CrispVotingAbi,
         address: PUB_CRISP_VOTING_PLUGIN_ADDRESS,
@@ -114,7 +200,7 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
         args: [proposalId],
       });
       await awaitSuccessfulReceipt(client, hash, "The refund claim");
-      await Promise.all([refetchPayer(), checkClaimed()]);
+      await Promise.all([refetchPayer(), refetchDistribution(), checkClaimed()]);
     } finally {
       setIsClaiming(false);
     }
@@ -129,6 +215,14 @@ export function useClaimRefund(proposalId: bigint | undefined, enabled = true) {
     isSelfPayer: Boolean(address && payerAddress && address.toLowerCase() === payerAddress.toLowerCase()),
     /** True once a `RefundClaimed` event exists for this proposal; undefined while unknown. */
     isClaimed,
+    /** The round is already in the `Failed` stage on-chain. */
+    isMarkedFailed,
+    /** The refund distribution has been calculated, so a claim can settle. */
+    isCalculated,
+    /** How much the requester is owed, once calculated. */
+    refundAmount,
+    /** How many transactions `claim()` will send from the current state. */
+    pendingSteps: (isMarkedFailed ? 0 : 1) + (isCalculated ? 0 : 1) + 1,
     isClaiming,
     claim,
   };

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -6,6 +6,7 @@ import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_DEPLOYMENT_BLOCK } from
 import { useTransactionManager } from "@/hooks/useTransactionManager";
 import { awaitSuccessfulReceipt } from "../utils/awaitReceipt";
 import { isRefundQueryStale } from "../utils/refundQuery";
+import { describeFailure } from "../utils/describeFailure";
 import { E3Stage } from "./useE3Status";
 
 const refundClaimedEvent = parseAbiItem(
@@ -160,8 +161,19 @@ export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | un
     onErrorMessage: "Could not claim the refund",
   });
 
+  /**
+   * Settlement can fail in ways `useTransactionManager` never sees: the preflight throws before
+   * any transaction is sent, and a reverted receipt is caught by `awaitSuccessfulReceipt` rather
+   * than by wagmi (which treats a mined-but-reverted transaction as a successful wait). The card
+   * discards the promise, so anything uncaught here becomes an unhandled rejection and the user
+   * is left staring at a button that did nothing.
+   */
+  const [error, setError] = useState<string | undefined>(undefined);
+
   const claim = async () => {
     if (proposalId === undefined || e3Id === undefined) return;
+
+    setError(undefined);
 
     try {
       setIsClaiming(true);
@@ -201,6 +213,13 @@ export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | un
       });
       await awaitSuccessfulReceipt(client, hash, "The refund claim");
       await Promise.all([refetchPayer(), refetchDistribution(), checkClaimed()]);
+    } catch (err) {
+      setError(describeFailure(err, "The refund could not be settled"));
+
+      // Settlement is several transactions and an earlier one may have landed before the
+      // failure. Re-read on-chain state so a retry resumes from where it stopped instead of
+      // repeating a step that would now revert.
+      await Promise.all([refetchStage(), refetchDistribution(), checkClaimed()]);
     } finally {
       setIsClaiming(false);
     }
@@ -223,6 +242,13 @@ export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | un
     refundAmount,
     /** How many transactions `claim()` will send from the current state. */
     pendingSteps: (isMarkedFailed ? 0 : 1) + (isCalculated ? 0 : 1) + 1,
+    /** Why the last settlement attempt failed, if it did. */
+    error,
+    /**
+     * The addresses `claim()` needs are loaded. Without this the button is clickable before the
+     * `interfold` read resolves, and settlement throws before sending anything.
+     */
+    isReady: Boolean(interfoldAddress),
     isClaiming,
     claim,
   };

--- a/plugins/crispVoting/hooks/useClaimRefund.ts
+++ b/plugins/crispVoting/hooks/useClaimRefund.ts
@@ -105,6 +105,18 @@ export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | un
   const refundAmount = (distribution as { requesterAmount?: bigint } | undefined)?.requesterAmount;
 
   /**
+   * Every read `claim()` branches on must have resolved.
+   *
+   * `isMarkedFailed` and `isCalculated` are false both when the step genuinely has not happened
+   * AND while their read is still in flight — the two are indistinguishable from the flags alone.
+   * Acting on the in-flight case re-sends a step that already completed, which reverts
+   * (`E3AlreadyFailed`) and costs the caller gas for nothing. Checking `interfoldAddress` alone
+   * was not enough: `stageRaw` and `distribution` resolve strictly after it, since their queries
+   * are chained off it.
+   */
+  const isReady = Boolean(interfoldAddress) && stageRaw !== undefined && distribution !== undefined;
+
+  /**
    * Identity of the newest status query, and the proposal currently on screen.
    * See `isRefundQueryStale` for why both are checked.
    */
@@ -170,8 +182,17 @@ export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | un
    */
   const [error, setError] = useState<string | undefined>(undefined);
 
+  // An error belongs to the proposal it happened on. Without this, navigating to another
+  // proposal carries the previous one's failure across and pins it to a round it never affected.
+  useEffect(() => {
+    setError(undefined);
+  }, [proposalId, e3Id]);
+
   const claim = async () => {
     if (proposalId === undefined || e3Id === undefined) return;
+    // Belt and braces alongside the disabled button: acting on unresolved reads re-sends a
+    // completed step and burns the caller's gas on a revert.
+    if (!isReady) return;
 
     setError(undefined);
 
@@ -244,11 +265,8 @@ export function useClaimRefund(proposalId: bigint | undefined, e3Id: bigint | un
     pendingSteps: (isMarkedFailed ? 0 : 1) + (isCalculated ? 0 : 1) + 1,
     /** Why the last settlement attempt failed, if it did. */
     error,
-    /**
-     * The addresses `claim()` needs are loaded. Without this the button is clickable before the
-     * `interfold` read resolves, and settlement throws before sending anything.
-     */
-    isReady: Boolean(interfoldAddress),
+    /** Every read `claim()` branches on has resolved; see the definition above. */
+    isReady,
     isClaiming,
     claim,
   };

--- a/plugins/crispVoting/hooks/useE3Status.ts
+++ b/plugins/crispVoting/hooks/useE3Status.ts
@@ -35,6 +35,7 @@ const pluginAbi = parseAbi(["function interfold() view returns (address)"]);
 const interfoldAbi = parseAbi([
   "function getE3Stage(uint256 e3Id) view returns (uint8)",
   "function getFailureReason(uint256 e3Id) view returns (uint8)",
+  "function checkFailureCondition(uint256 e3Id) view returns (bool canFail, uint8 reason)",
 ]);
 
 /** Human-readable description of an E3 failure reason. */
@@ -107,5 +108,34 @@ export function useE3Status(e3Id: bigint | undefined, enabled = true) {
 
   const failureReason = reasonRaw === undefined ? undefined : (Number(reasonRaw) as E3FailureReason);
 
-  return { stage, isFailed, failureReason };
+  // A round does not mark itself failed. `markE3Failed` is a permissionless transaction someone
+  // has to send once a stage deadline passes, so a round whose DKG timed out days ago still reads
+  // as `CommitteeFinalized` until then — alive on-chain, and dead in every way that matters.
+  // `checkFailureCondition` is what Interfold would act on, so it is the honest signal to show.
+  const { data: pending } = useReadContract({
+    chainId: PUB_CHAIN_ID,
+    address: interfold as Address | undefined,
+    abi: interfoldAbi,
+    functionName: "checkFailureCondition",
+    args: [e3Id ?? 0n],
+    query: { enabled: active && !!interfold && !isFailed },
+  });
+
+  const [canFail, pendingReasonRaw] = (pending as readonly [boolean, number] | undefined) ?? [];
+
+  /** Terminal either way: the round can never produce a tally. */
+  const isDead = isFailed || canFail === true;
+
+  return {
+    stage,
+    isFailed,
+    failureReason: isFailed
+      ? failureReason
+      : pendingReasonRaw === undefined
+        ? undefined
+        : (Number(pendingReasonRaw) as E3FailureReason),
+    /** The failure condition is met but nobody has sent `markE3Failed` yet. */
+    isFailurePending: !isFailed && canFail === true,
+    isDead,
+  };
 }

--- a/plugins/crispVoting/hooks/useFeeEscrow.ts
+++ b/plugins/crispVoting/hooks/useFeeEscrow.ts
@@ -5,6 +5,7 @@ import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_ENCLAVE_FEE_TOKEN_ADDRESS } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
 import { awaitSuccessfulReceipt } from "../utils/awaitReceipt";
+import { describeFailure } from "../utils/describeFailure";
 
 export type FeeEscrow = {
   /** Fee-token credit escrowed in the plugin for this account (`feeCredits`). */
@@ -18,6 +19,8 @@ export type FeeEscrow = {
   isLoading: boolean;
   /** A deposit or withdrawal is in flight. */
   isBusy: boolean;
+  /** Why the last deposit or withdrawal failed, if it did. */
+  error?: string;
   /** Escrows `amount` of the fee token, approving first when the allowance is short. */
   deposit: (amount: bigint) => Promise<void>;
   /** Returns `amount` of unused credit to the wallet. */
@@ -38,6 +41,11 @@ export function useFeeEscrow(): FeeEscrow {
   const { address } = useAccount();
   const client = usePublicClient();
   const [isBusy, setIsBusy] = useState(false);
+  // Both actions can throw where `useTransactionManager` never sees it — the client guard fires
+  // before any transaction is sent, and a reverted receipt is caught by `awaitSuccessfulReceipt`
+  // rather than by wagmi. The card discards these promises, so an uncaught throw is an unhandled
+  // rejection and a button that silently does nothing.
+  const [error, setError] = useState<string | undefined>(undefined);
 
   const {
     data,
@@ -110,6 +118,8 @@ export function useFeeEscrow(): FeeEscrow {
   const deposit = async (amount: bigint) => {
     if (amount <= 0n) return;
 
+    setError(undefined);
+
     try {
       setIsBusy(true);
       const publicClient = requireClient();
@@ -124,6 +134,9 @@ export function useFeeEscrow(): FeeEscrow {
       });
       await awaitSuccessfulReceipt(publicClient, hash, "The deposit");
       await refetchReads();
+    } catch (err) {
+      setError(describeFailure(err, "The deposit could not be completed"));
+      await refetchReads();
     } finally {
       setIsBusy(false);
     }
@@ -131,6 +144,8 @@ export function useFeeEscrow(): FeeEscrow {
 
   const withdraw = async (amount: bigint) => {
     if (amount <= 0n) return;
+
+    setError(undefined);
 
     try {
       setIsBusy(true);
@@ -143,6 +158,9 @@ export function useFeeEscrow(): FeeEscrow {
         args: [amount],
       });
       await awaitSuccessfulReceipt(publicClient, hash, "The withdrawal");
+      await refetchReads();
+    } catch (err) {
+      setError(describeFailure(err, "The withdrawal could not be completed"));
       await refetchReads();
     } finally {
       setIsBusy(false);
@@ -191,6 +209,7 @@ export function useFeeEscrow(): FeeEscrow {
     decimals: decimals === undefined ? undefined : Number(decimals),
     isLoading: Boolean(address) && isLoading,
     isBusy,
+    error,
     deposit,
     withdraw,
     refetch: () => void refetchReads(),

--- a/plugins/crispVoting/hooks/useFeeEscrow.ts
+++ b/plugins/crispVoting/hooks/useFeeEscrow.ts
@@ -1,6 +1,6 @@
 import { useAccount, usePublicClient, useReadContracts } from "wagmi";
 import { erc20Abi, type Address } from "viem";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CrispVotingAbi } from "../artifacts/CrispVoting";
 import { PUB_CHAIN, PUB_CRISP_VOTING_PLUGIN_ADDRESS, PUB_ENCLAVE_FEE_TOKEN_ADDRESS } from "@/constants";
 import { useTransactionManager } from "@/hooks/useTransactionManager";
@@ -46,6 +46,12 @@ export function useFeeEscrow(): FeeEscrow {
   // rather than by wagmi. The card discards these promises, so an uncaught throw is an unhandled
   // rejection and a button that silently does nothing.
   const [error, setError] = useState<string | undefined>(undefined);
+
+  // An error belongs to the account that hit it. Switching wallets otherwise carries the previous
+  // account's failure over and shows it against balances it has nothing to do with.
+  useEffect(() => {
+    setError(undefined);
+  }, [address]);
 
   const {
     data,

--- a/plugins/crispVoting/hooks/useProposal.ts
+++ b/plugins/crispVoting/hooks/useProposal.ts
@@ -63,14 +63,19 @@ export function useProposal(proposalId: bigint) {
 
   const proposalRaw = proposalResult as Proposal | undefined;
 
-  // Fallback: when the CRISP server can't give us a usable round state (committee
-  // not ready and not tallied), consult the Enclave/Interfold contract for the
-  // authoritative E3 stage — this is how we detect a failed round (e.g. the
-  // committee couldn't be formed or DKG timed out).
-  const { isFailed: e3Failed, failureReason: e3FailureReason } = useE3Status(
-    proposalRaw?.e3Id,
-    !isCommitteeReady && !isTallied
-  );
+  // Interfold is the authority on whether a round failed, so ask it about anything not yet
+  // tallied — not just rounds whose committee never formed.
+  //
+  // Gating on `!isCommitteeReady` (the previous behaviour) meant a round that formed its
+  // committee and then died later was never checked at all: every post-DKG failure reason
+  // (ComputeTimeout, ComputeProviderExpired, ComputeProviderFailed, DecryptionTimeout,
+  // DecryptionInvalidShares, VerificationFailed) landed on a proposal the UI still showed as
+  // healthy. A tallied round is terminal and cannot fail afterwards, so that gate stays.
+  const {
+    isDead: e3Failed,
+    isFailurePending: e3FailurePending,
+    failureReason: e3FailureReason,
+  } = useE3Status(proposalRaw?.e3Id, !isTallied);
 
   const tally: Tally = useMemo(() => {
     if (!tallyResult) return [];
@@ -178,6 +183,7 @@ export function useProposal(proposalId: bigint) {
     isCommitteeReady,
     totalVotingPower,
     e3Failed,
+    e3FailurePending,
     e3FailureReason,
     status: {
       proposalReady: proposalFetchStatus === "idle",

--- a/plugins/crispVoting/hooks/useProposalStatus.ts
+++ b/plugins/crispVoting/hooks/useProposalStatus.ts
@@ -72,14 +72,17 @@ export const useProposalStatus = (proposal: Proposal, e3Failed = false) => {
           Number(decimals ?? 18)
         );
 
-    if (proposal?.active) {
+    // Checked BEFORE `active`. `active` means only "the end date is in the future", and the
+    // most common failures — committee formation timeout, DKG timeout — happen early, well
+    // inside the voting window. Testing `active` first therefore advertised a dead round as
+    // open for votes until its end date passed, with a vote card people could still click.
+    // A failed round is terminal: it can never be tallied or executed.
+    if (e3Failed) {
+      setStatus(ProposalStatus.REJECTED);
+    } else if (proposal?.active) {
       setStatus(ProposalStatus.ACTIVE);
     } else if (proposal?.executed) {
       setStatus(ProposalStatus.EXECUTED);
-    } else if (e3Failed) {
-      // The encrypted vote round failed on-chain (e.g. committee/DKG failure):
-      // it can never be tallied or executed.
-      setStatus(ProposalStatus.REJECTED);
     } else if (!proposal?.isTallied) {
       setStatus(ProposalStatus.PENDING);
     } else if (totalVotes === 0n) {

--- a/plugins/crispVoting/pages/proposal.tsx
+++ b/plugins/crispVoting/pages/proposal.tsx
@@ -29,6 +29,7 @@ export default function ProposalDetail({ index: proposalIdx }: { index: bigint }
     proposal,
     isCommitteeReady,
     e3Failed,
+    e3FailurePending,
     e3FailureReason,
     status: proposalFetchStatus,
   } = useProposal(proposalIdx);
@@ -146,9 +147,10 @@ export default function ProposalDetail({ index: proposalIdx }: { index: bigint }
                 creditMode={proposal.parameters.creditMode}
                 e3Failed={e3Failed}
                 e3FailureReason={e3FailureReason}
+                e3FailurePending={e3FailurePending}
               />
             )}
-            {e3Failed && <RefundCard proposalId={proposalIdx} />}
+            {e3Failed && <RefundCard proposalId={proposalIdx} e3Id={proposal.e3Id} />}
             <CardResources resources={proposal.resources} title="Resources" />
           </div>
         </div>

--- a/plugins/crispVoting/utils/describeFailure.ts
+++ b/plugins/crispVoting/utils/describeFailure.ts
@@ -1,0 +1,16 @@
+/**
+ * Turns a thrown transaction error into something worth showing a user.
+ *
+ * Returns `undefined` for a declined signature: `useTransactionManager` already raises its own
+ * alert for that, and it is a deliberate choice rather than a failure to report twice.
+ *
+ * @param err The caught error.
+ * @param fallback Message to use when the error carries nothing readable.
+ */
+export function describeFailure(err: unknown, fallback: string): string | undefined {
+  const message = (err as { shortMessage?: string })?.shortMessage ?? (err as Error)?.message ?? fallback;
+
+  if (/user rejected/i.test(message)) return undefined;
+
+  return message;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer “Round failed” labels and badges across proposal lists, headers, and voting results.
  * Added messaging when a failed round can be finalized to unlock refunds.
  * Enhanced refund processing with amounts, payer details, pending steps, and settlement progress.
  * Refund flows can resume after partial completion and guide users through each required step.
* **Bug Fixes**
  * Failed rounds are now correctly identified as rejected, even while voting remains open.
  * Failure and refund statuses update more reliably across proposal views.
  * Added clearer error alerts for failed escrow and refund transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->